### PR TITLE
Allow to optionally show "Total" in most dashboard entry types

### DIFF
--- a/dashboard/convert/entry.go
+++ b/dashboard/convert/entry.go
@@ -49,6 +49,7 @@ func ToExternalEntry(entry model.DashboardEntry) (*gqlmodel.DashboardEntry, erro
 	return &gqlmodel.DashboardEntry{
 		ID:             entry.ID,
 		Title:          entry.Title,
+		Total:          entry.Total,
 		Pos:            &pos,
 		StatsSelection: stats,
 		EntryType:      ExternalEntryType(entry.Type),

--- a/dashboard/dbrange/ranges_test.go
+++ b/dashboard/dbrange/ranges_test.go
@@ -150,7 +150,7 @@ func TestRanges(t *testing.T) {
 	})
 	require.EqualError(t, err, "dashboard range does not exist")
 
-	entry, err := resolver.AddDashboardEntry(user1, 1, gqlmodel.EntryTypeBarChart, "other", gqlmodel.InputStatsSelection{
+	entry, err := resolver.AddDashboardEntry(user1, 1, gqlmodel.EntryTypeBarChart, "other", true, gqlmodel.InputStatsSelection{
 		Interval: gqlmodel.StatsIntervalDaily,
 		Tags:     []string{"abc"},
 		RangeID:  &xrange.ID,

--- a/dashboard/entry/add.go
+++ b/dashboard/entry/add.go
@@ -17,7 +17,7 @@ import (
 )
 
 // AddDashboardEntry adds a dashboard entry.
-func (r *ResolverForEntry) AddDashboardEntry(ctx context.Context, dashboardID int, entryType gqlmodel.EntryType, title string, stats gqlmodel.InputStatsSelection, pos *gqlmodel.InputResponsiveDashboardEntryPos) (*gqlmodel.DashboardEntry, error) {
+func (r *ResolverForEntry) AddDashboardEntry(ctx context.Context, dashboardID int, entryType gqlmodel.EntryType, title string, total bool, stats gqlmodel.InputStatsSelection, pos *gqlmodel.InputResponsiveDashboardEntryPos) (*gqlmodel.DashboardEntry, error) {
 	userID := auth.GetUser(ctx).ID
 
 	if _, err := util.FindDashboard(r.DB, userID, dashboardID); err != nil {
@@ -28,6 +28,7 @@ func (r *ResolverForEntry) AddDashboardEntry(ctx context.Context, dashboardID in
 		Keys:            strings.Join(stats.Tags, ","),
 		Type:            convert.InternalEntryType(entryType),
 		Title:           title,
+		Total:           total,
 		DashboardID:     dashboardID,
 		Interval:        convert.InternalInterval(stats.Interval),
 		MobilePosition:  convert.EmptyPos(),

--- a/dashboard/entry/update.go
+++ b/dashboard/entry/update.go
@@ -16,7 +16,7 @@ import (
 )
 
 // UpdateDashboardEntry updates a dashboard entry.
-func (r *ResolverForEntry) UpdateDashboardEntry(ctx context.Context, id int, entryType *gqlmodel.EntryType, title *string, stats *gqlmodel.InputStatsSelection, pos *gqlmodel.InputResponsiveDashboardEntryPos) (*gqlmodel.DashboardEntry, error) {
+func (r *ResolverForEntry) UpdateDashboardEntry(ctx context.Context, id int, entryType *gqlmodel.EntryType, title *string, total *bool, stats *gqlmodel.InputStatsSelection, pos *gqlmodel.InputResponsiveDashboardEntryPos) (*gqlmodel.DashboardEntry, error) {
 	userID := auth.GetUser(ctx).ID
 
 	entry, err := util.FindDashboardEntry(r.DB, id)
@@ -31,6 +31,11 @@ func (r *ResolverForEntry) UpdateDashboardEntry(ctx context.Context, id int, ent
 	if title != nil {
 		entry.Title = *title
 	}
+
+	if total != nil {
+		entry.Total = *total
+	}
+
 	if stats != nil {
 		if stats.RangeID != nil {
 			if _, err := util.FindDashboardRange(r.DB, *stats.RangeID); err != nil {

--- a/model/dashboard.go
+++ b/model/dashboard.go
@@ -29,6 +29,7 @@ type DashboardEntry struct {
 	ID          int `gorm:"primary_key;unique_index;AUTO_INCREMENT"`
 	DashboardID int `gorm:"type:int REFERENCES dashboards(id) ON DELETE CASCADE"`
 	Title       string
+	Total       bool
 	Type        DashboardType
 	Keys        string
 	Interval    Interval

--- a/model/dashboard.go
+++ b/model/dashboard.go
@@ -29,7 +29,7 @@ type DashboardEntry struct {
 	ID          int `gorm:"primary_key;unique_index;AUTO_INCREMENT"`
 	DashboardID int `gorm:"type:int REFERENCES dashboards(id) ON DELETE CASCADE"`
 	Title       string
-	Total       bool
+	Total       bool `gorm:"default:false"`
 	Type        DashboardType
 	Keys        string
 	Interval    Interval

--- a/schema.graphql
+++ b/schema.graphql
@@ -40,8 +40,8 @@ type RootMutation {
     updateDashboardRange(rangeId: Int!, range: InputNamedDateRange!): NamedDateRange
     removeDashboardRange(rangeId: Int!): NamedDateRange
 
-    addDashboardEntry(dashboardId: Int!, entryType: EntryType!, title: String!, stats: InputStatsSelection!, pos: InputResponsiveDashboardEntryPos): DashboardEntry @hasRole(role: USER)
-    updateDashboardEntry(entryId: Int!, entryType: EntryType, title: String, stats: InputStatsSelection, pos: InputResponsiveDashboardEntryPos): DashboardEntry @hasRole(role: USER)
+    addDashboardEntry(dashboardId: Int!, entryType: EntryType!, title: String!, total: Boolean!, stats: InputStatsSelection!, pos: InputResponsiveDashboardEntryPos): DashboardEntry @hasRole(role: USER)
+    updateDashboardEntry(entryId: Int!, entryType: EntryType, title: String, total: Boolean, stats: InputStatsSelection, pos: InputResponsiveDashboardEntryPos): DashboardEntry @hasRole(role: USER)
     removeDashboardEntry(id: Int!): DashboardEntry! @hasRole(role: USER)
 
     setUserSettings(settings: InputUserSettings!): UserSettings! @hasRole(role: USER)
@@ -251,6 +251,7 @@ input InputRelativeOrStaticRange {
 type DashboardEntry {
     id: Int!
     title: String!
+    total: Boolean!
     statsSelection: StatsSelection!
     pos: ResponsiveDashboardEntryPos!
     entryType: EntryType!

--- a/ui/src/dashboard/DashboardPage.tsx
+++ b/ui/src/dashboard/DashboardPage.tsx
@@ -74,6 +74,7 @@ const newEntry = (): Dashboards_dashboards_items => {
                 __typename: 'DashboardEntryPos',
             },
         },
+        total: false,
     };
 };
 

--- a/ui/src/dashboard/Entry/AddPopup.tsx
+++ b/ui/src/dashboard/Entry/AddPopup.tsx
@@ -78,6 +78,7 @@ export const AddPopup: React.FC<EditPopupProps> = ({
                                             dashboardId,
                                             entryType: entry.entryType,
                                             title: entry.title,
+                                            total: entry.total,
                                             stats: {
                                                 tags: entry.statsSelection.tags,
                                                 interval: entry.statsSelection.interval,

--- a/ui/src/dashboard/Entry/DashboardBarChart.tsx
+++ b/ui/src/dashboard/Entry/DashboardBarChart.tsx
@@ -12,6 +12,7 @@ interface DashboardPieChartProps {
     entries: Stats_stats[];
     interval: StatsInterval;
     type: 'stacked' | 'normal';
+    total: boolean;
 }
 
 interface Indexed {
@@ -20,7 +21,7 @@ interface Indexed {
     data: Record<string, number>;
 }
 
-export const DashboardBarChart: React.FC<DashboardPieChartProps> = ({entries, interval, type}) => {
+export const DashboardBarChart: React.FC<DashboardPieChartProps> = ({entries, interval, type, total}) => {
     const indexedEntries: Indexed[] = entries
         .map((entry) => {
             return {
@@ -46,7 +47,7 @@ export const DashboardBarChart: React.FC<DashboardPieChartProps> = ({entries, in
             <BarChart data={indexedEntries}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <YAxis type="number" unit={unit.short} />
-                <Tooltip content={<TagTooltip dateFormat={dateFormat} />} />
+                <Tooltip content={<TagTooltip dateFormat={dateFormat} total={total} />} />
                 <Legend />
                 <XAxis dataKey={(entry) => dateFormat(moment(entry.start))} interval={'preserveStartEnd'} />
 

--- a/ui/src/dashboard/Entry/DashboardEntry.tsx
+++ b/ui/src/dashboard/Entry/DashboardEntry.tsx
@@ -88,7 +88,7 @@ const SpecificDashboardEntry: React.FC<{entry: Dashboards_dashboards_items; rang
                     </Center>
                 );
             }
-            return <DashboardBarChart entries={entries} interval={interval} type="normal" />;
+            return <DashboardBarChart entries={entries} interval={interval} type="normal" total={entry.total} />;
         case EntryType.StackedBarChart:
             if (entries.length === 0) {
                 return (
@@ -97,7 +97,7 @@ const SpecificDashboardEntry: React.FC<{entry: Dashboards_dashboards_items; rang
                     </Center>
                 );
             }
-            return <DashboardBarChart entries={entries} interval={interval} type="stacked" />;
+            return <DashboardBarChart entries={entries} interval={interval} type="stacked" total={entry.total} />;
         case EntryType.LineChart:
             if (entries.length === 0) {
                 return (
@@ -106,7 +106,7 @@ const SpecificDashboardEntry: React.FC<{entry: Dashboards_dashboards_items; rang
                     </Center>
                 );
             }
-            return <DashboardLineChart entries={entries} interval={interval} />;
+            return <DashboardLineChart entries={entries} interval={interval} total={entry.total} />;
         case EntryType.VerticalTable:
             if (entries.length === 0) {
                 return (
@@ -115,7 +115,7 @@ const SpecificDashboardEntry: React.FC<{entry: Dashboards_dashboards_items; rang
                     </Center>
                 );
             }
-            return <DashboardTable mode="vertical" entries={entries} interval={interval} />;
+            return <DashboardTable mode="vertical" entries={entries} interval={interval} total={entry.total} />;
         case EntryType.HorizontalTable:
             if (entries.length === 0) {
                 return (
@@ -124,7 +124,7 @@ const SpecificDashboardEntry: React.FC<{entry: Dashboards_dashboards_items; rang
                     </Center>
                 );
             }
-            return <DashboardTable mode="horizontal" entries={entries} interval={interval} />;
+            return <DashboardTable mode="horizontal" entries={entries} interval={interval} total={entry.total} />;
         default:
             return expectNever(entry.entryType);
     }

--- a/ui/src/dashboard/Entry/DashboardEntryForm.tsx
+++ b/ui/src/dashboard/Entry/DashboardEntryForm.tsx
@@ -39,6 +39,21 @@ export const DashboardEntryForm: React.FC<EditPopupProps> = ({entry, onChange: s
               __typename: 'RelativeOrStaticRange',
           };
 
+    const getTotalTitle = (entryType: EntryType) => {
+        switch (entryType) {
+            case EntryType.HorizontalTable:
+                return 'Show "Total" row:';
+            case EntryType.VerticalTable:
+                return 'Show "Total" column:';
+            case EntryType.BarChart:
+            case EntryType.StackedBarChart:
+            case EntryType.LineChart:
+                return 'Show "Total" in tooltip:';
+            default:
+                return '';
+        }
+    };
+
     return (
         <>
             <TextField
@@ -162,6 +177,24 @@ export const DashboardEntryForm: React.FC<EditPopupProps> = ({entry, onChange: s
                         </option>
                     ))}
                 </Select>
+            )}
+            {entry.entryType !== EntryType.PieChart ? (
+                <Typography component="div">
+                    <Grid component="label" container alignItems="center" spacing={1}>
+                        <Grid item>{getTotalTitle(entry.entryType)}</Grid>
+                        <Grid item>
+                            <Switch
+                                checked={entry.total}
+                                onChange={(e) => {
+                                    entry.total = e.target.checked;
+                                    setEntry(entry);
+                                }}
+                            />
+                        </Grid>
+                    </Grid>
+                </Typography>
+            ) : (
+                undefined
             )}
             <TagKeySelector
                 value={entry.statsSelection.tags || []}

--- a/ui/src/dashboard/Entry/DashboardEntryForm.tsx
+++ b/ui/src/dashboard/Entry/DashboardEntryForm.tsx
@@ -39,21 +39,6 @@ export const DashboardEntryForm: React.FC<EditPopupProps> = ({entry, onChange: s
               __typename: 'RelativeOrStaticRange',
           };
 
-    const getTotalTitle = (entryType: EntryType) => {
-        switch (entryType) {
-            case EntryType.HorizontalTable:
-                return 'Show "Total" row:';
-            case EntryType.VerticalTable:
-                return 'Show "Total" column:';
-            case EntryType.BarChart:
-            case EntryType.StackedBarChart:
-            case EntryType.LineChart:
-                return 'Show "Total" in tooltip:';
-            default:
-                return '';
-        }
-    };
-
     return (
         <>
             <TextField
@@ -206,4 +191,19 @@ export const DashboardEntryForm: React.FC<EditPopupProps> = ({entry, onChange: s
             />
         </>
     );
+};
+
+const getTotalTitle = (entryType: EntryType) => {
+    switch (entryType) {
+        case EntryType.HorizontalTable:
+            return 'Show "Total" row:';
+        case EntryType.VerticalTable:
+            return 'Show "Total" column:';
+        case EntryType.BarChart:
+        case EntryType.StackedBarChart:
+        case EntryType.LineChart:
+            return 'Show "Total" in tooltip:';
+        default:
+            return '';
+    }
 };

--- a/ui/src/dashboard/Entry/DashboardLineChart.tsx
+++ b/ui/src/dashboard/Entry/DashboardLineChart.tsx
@@ -11,6 +11,7 @@ import {TagTooltip} from './TagTooltip';
 interface DashboardPieChartProps {
     entries: Stats_stats[];
     interval: StatsInterval;
+    total: boolean;
 }
 
 interface Indexed {
@@ -19,7 +20,7 @@ interface Indexed {
     data: Record<string, number>;
 }
 
-export const DashboardLineChart: React.FC<DashboardPieChartProps> = ({entries, interval}) => {
+export const DashboardLineChart: React.FC<DashboardPieChartProps> = ({entries, interval, total}) => {
     const indexedEntries: Indexed[] = entries
         .map((entry) => {
             return {
@@ -45,7 +46,7 @@ export const DashboardLineChart: React.FC<DashboardPieChartProps> = ({entries, i
             <LineChart data={indexedEntries}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <YAxis type="number" unit={unit.short} />
-                <Tooltip content={<TagTooltip dateFormat={dateFormat} />} />
+                <Tooltip content={<TagTooltip dateFormat={dateFormat} total={total} />} />
                 <Legend />
                 <XAxis dataKey={(entry) => dateFormat(moment(entry.start))} interval={'preserveStartEnd'} />
 

--- a/ui/src/dashboard/Entry/DashboardTable.tsx
+++ b/ui/src/dashboard/Entry/DashboardTable.tsx
@@ -11,6 +11,7 @@ interface DashboardTableProps {
     entries: Stats_stats[];
     interval: StatsInterval;
     mode: 'vertical' | 'horizontal';
+    total: boolean;
 }
 
 interface Indexed {
@@ -19,16 +20,24 @@ interface Indexed {
     data: Record<string, number>;
 }
 
-export const DashboardTable: React.FC<DashboardTableProps> = ({entries, interval, mode}) => {
+export const DashboardTable: React.FC<DashboardTableProps> = ({entries, interval, mode, total}) => {
     const indexedEntries: Indexed[] = entries
         .map((entry) => {
-            return {
+            const result = {
                 start: entry.start,
                 end: entry.end,
                 data: entry.entries!.reduce((all: Record<string, number>, current) => {
                     return {...all, [current.key + ':' + current.value]: current.timeSpendInSeconds};
                 }, {}),
             };
+            if (total) {
+                let sum = 0;
+                Object.keys(result.data).forEach((item) => {
+                    sum += result.data[item];
+                });
+                result.data['Total'] = sum;
+            }
+            return result;
         })
         .sort((left, right) => moment(left.start).diff(right.start));
     const dateFormat = ofInterval(interval);

--- a/ui/src/dashboard/Entry/DashboardTable.tsx
+++ b/ui/src/dashboard/Entry/DashboardTable.tsx
@@ -31,11 +31,7 @@ export const DashboardTable: React.FC<DashboardTableProps> = ({entries, interval
                 }, {}),
             };
             if (total) {
-                let sum = 0;
-                Object.keys(result.data).forEach((item) => {
-                    sum += result.data[item];
-                });
-                result.data['Total'] = sum;
+                result.data['Total'] = Object.values(result.data).reduce((acc, value) => acc + value);
             }
             return result;
         })

--- a/ui/src/dashboard/Entry/EditPopup.tsx
+++ b/ui/src/dashboard/Entry/EditPopup.tsx
@@ -64,6 +64,7 @@ export const EditPopup: React.FC<EditPopupProps> = ({entry, anchorEl, onChange: 
                                             entryId: entry.id,
                                             entryType: entry.entryType,
                                             title: entry.title,
+                                            total: entry.total,
                                             stats: {
                                                 tags: entry.statsSelection.tags,
                                                 interval: entry.statsSelection.interval,

--- a/ui/src/dashboard/Entry/TagTooltip.tsx
+++ b/ui/src/dashboard/Entry/TagTooltip.tsx
@@ -6,21 +6,25 @@ import moment from 'moment-timezone';
 import prettyMs from 'pretty-ms';
 import * as React from 'react';
 
-export const TagTooltip = ({active, payload, dateFormat}: TooltipProps & {dateFormat: FInterval}) => {
+export const TagTooltip = ({active, payload, dateFormat, total}: TooltipProps & {dateFormat: FInterval; total: boolean}) => {
     if (active && payload) {
         const first = payload[0];
         const start = dateFormat(moment(first.payload.start));
         const end = dateFormat(moment(first.payload.end));
+        let sum = 0;
+
         return (
             <Paper style={{padding: 10}} elevation={4}>
                 {first && <Typography variant={'subtitle2'}>{start === end ? `${start}` : `${start} - ${end}`}</Typography>}
                 {payload.map((entry) => {
+                    sum += entry.payload.data[entry.name] as number;
                     return (
                         <Typography key={entry.name}>
                             {entry.name}: {prettyMs((entry.payload.data[entry.name] as number) * 1000)}
                         </Typography>
                     );
                 })}
+                {total ? <Typography>Total: {prettyMs(sum * 1000)}</Typography> : undefined}
             </Paper>
         );
     }

--- a/ui/src/dashboard/Entry/TagTooltip.tsx
+++ b/ui/src/dashboard/Entry/TagTooltip.tsx
@@ -25,7 +25,9 @@ export const TagTooltip = ({active, payload, dateFormat, total}: TooltipProps & 
                         Total:
                         {prettyMs(sum(payload) * 1000)}
                     </Typography>
-                ) : undefined}
+                ) : (
+                    undefined
+                )}
             </Paper>
         );
     }

--- a/ui/src/dashboard/Entry/TagTooltip.tsx
+++ b/ui/src/dashboard/Entry/TagTooltip.tsx
@@ -1,4 +1,4 @@
-import {TooltipProps} from 'recharts';
+import {TooltipProps, TooltipPayload} from 'recharts';
 import {FInterval} from './dateformat';
 import Paper from '@material-ui/core/Paper';
 import {Typography} from '@material-ui/core';
@@ -11,23 +11,27 @@ export const TagTooltip = ({active, payload, dateFormat, total}: TooltipProps & 
         const first = payload[0];
         const start = dateFormat(moment(first.payload.start));
         const end = dateFormat(moment(first.payload.end));
-        let sum = 0;
 
         return (
             <Paper style={{padding: 10}} elevation={4}>
                 {first && <Typography variant={'subtitle2'}>{start === end ? `${start}` : `${start} - ${end}`}</Typography>}
-                {payload.map((entry) => {
-                    sum += entry.payload.data[entry.name] as number;
-                    return (
-                        <Typography key={entry.name}>
-                            {entry.name}: {prettyMs((entry.payload.data[entry.name] as number) * 1000)}
-                        </Typography>
-                    );
-                })}
-                {total ? <Typography>Total: {prettyMs(sum * 1000)}</Typography> : undefined}
+                {payload.map((entry) => (
+                    <Typography key={entry.name}>
+                        {entry.name}: {prettyMs((entry.payload.data[entry.name] as number) * 1000)}
+                    </Typography>
+                ))}
+                {total ? (
+                    <Typography>
+                        Total:
+                        {prettyMs(sum(payload) * 1000)}
+                    </Typography>
+                ) : undefined}
             </Paper>
         );
     }
 
     return null;
 };
+
+const sum = (payload: readonly TooltipPayload[]): number =>
+    payload.reduce((acc, entry) => (acc + entry.payload.data[entry.name]) as number, 0);

--- a/ui/src/gql/dashboard.ts
+++ b/ui/src/gql/dashboard.ts
@@ -17,6 +17,7 @@ export const Dashboards = gql`
             items {
                 id
                 title
+                total
                 entryType
                 statsSelection {
                     range {
@@ -90,8 +91,14 @@ export const UpdatePos = gql`
 `;
 
 export const UpdateDashboardEntry = gql`
-    mutation UpdateDashboardEntry($entryId: Int!, $entryType: EntryType!, $title: String!, $stats: InputStatsSelection!) {
-        updateDashboardEntry(entryId: $entryId, entryType: $entryType, title: $title, stats: $stats) {
+    mutation UpdateDashboardEntry(
+        $entryId: Int!
+        $entryType: EntryType!
+        $title: String!
+        $total: Boolean!
+        $stats: InputStatsSelection!
+    ) {
+        updateDashboardEntry(entryId: $entryId, entryType: $entryType, title: $title, total: $total, stats: $stats) {
             id
         }
     }
@@ -101,10 +108,18 @@ export const AddDashboardEntry = gql`
         $dashboardId: Int!
         $entryType: EntryType!
         $title: String!
+        $total: Boolean!
         $stats: InputStatsSelection!
         $pos: InputResponsiveDashboardEntryPos
     ) {
-        addDashboardEntry(dashboardId: $dashboardId, entryType: $entryType, title: $title, stats: $stats, pos: $pos) {
+        addDashboardEntry(
+            dashboardId: $dashboardId
+            entryType: $entryType
+            title: $title
+            total: $total
+            stats: $stats
+            pos: $pos
+        ) {
             id
         }
     }


### PR DESCRIPTION
This is my first attempt to implement https://github.com/traggo/server/issues/88

The Dashboard Entry Editor allows to choose Total Hidden/Visible for all table types:
![image](https://user-images.githubusercontent.com/12165268/109342201-cb258680-786b-11eb-8ba2-5ff1b7270fc3.png)
![image](https://user-images.githubusercontent.com/12165268/109342233-d8db0c00-786b-11eb-8d07-c65ad7f5c7da.png)

Sample dashboard:
![image](https://user-images.githubusercontent.com/12165268/109343427-a5997c80-786d-11eb-8f1f-85de92adfcda.png)
