### PR TITLE
Introduce docker development setup.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+/docker/Dockerfile.dev
+/docker/Dockerfile
+/ui/node_modules/
+.idea/
+build/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  traggo:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.dev
+    environment:
+      TRAGGO_DEFAULT_USER_NAME: "admin"
+      TRAGGO_DEFAULT_USER_PASS: "admin"
+
+      TRAGGO_LOG_LEVEL: debug
+    ports:
+      - 3030:3030
+    volumes:
+      - .traggodata:/opt/traggo/data

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,15 @@
+FROM golang:1.18.1 as builder
+
+RUN apt-get update && apt-get install --yes nodejs npm && npm install --global yarn
+
+WORKDIR /app
+COPY . .
+
+ENV GO111MODULE=on
+RUN make download-tools install generate build-bin-local
+
+FROM scratch
+WORKDIR /opt/traggo
+COPY --from=builder /app/build/traggo-server /opt/traggo/traggo
+EXPOSE 3030
+ENTRYPOINT ["./traggo"]


### PR DESCRIPTION
A working traggo instance can now be started by simply running
`docker-compose up --build`.

Fixes #115 