### PR TITLE
add hotkeys for unslecting and deleting timespans

### DIFF
--- a/ui/src/timespan/TimeSpan.tsx
+++ b/ui/src/timespan/TimeSpan.tsx
@@ -16,14 +16,13 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import {RemoveTimeSpan, RemoveTimeSpanVariables} from '../gql/__generated__/RemoveTimeSpan';
 import {useStateAndDelegateWithDelayOnChange} from '../utils/hooks';
-import {TimeSpans} from '../gql/__generated__/TimeSpans';
 import {isSameDate} from '../utils/time';
-import {Trackers} from '../gql/__generated__/Trackers';
 import {addTimeSpanToCache, removeFromTrackersCache} from '../gql/utils';
 import {StartTimer, StartTimerVariables} from '../gql/__generated__/StartTimer';
 import {RelativeTime, RelativeToNow} from '../common/RelativeTime';
 import ShowNotesIcon from '@material-ui/icons/KeyboardArrowDown';
 import HideNotesIcon from '@material-ui/icons/KeyboardArrowUp';
+import {removeTimeSpanOptions} from "./mutations";
 
 interface Range {
     from: moment.Moment;
@@ -82,40 +81,7 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
             clearTimeout(note.current.handle);
             return updateTimeSpan({variables: {...variables, note: note.current.value}});
         };
-        const [removeTimeSpan] = useMutation<RemoveTimeSpan, RemoveTimeSpanVariables>(gqlTimeSpan.RemoveTimeSpan, {
-            update: (cache, {data}) => {
-                let oldData: TimeSpans | null = null;
-                try {
-                    oldData = cache.readQuery<TimeSpans>({query: gqlTimeSpan.TimeSpans});
-                } catch (e) {}
-
-                const oldTrackers = cache.readQuery<Trackers>({query: gqlTimeSpan.Trackers});
-                if (!data || !data.removeTimeSpan) {
-                    return;
-                }
-                const removedId = data.removeTimeSpan.id;
-                if (oldTrackers) {
-                    cache.writeQuery<Trackers>({
-                        query: gqlTimeSpan.Trackers,
-                        data: {
-                            timers: (oldTrackers.timers || []).filter((tracker) => tracker.id !== removedId),
-                        },
-                    });
-                }
-                if (oldData) {
-                    cache.writeQuery<TimeSpans>({
-                        query: gqlTimeSpan.TimeSpans,
-                        data: {
-                            timeSpans: {
-                                __typename: 'PagedTimeSpans',
-                                timeSpans: oldData.timeSpans.timeSpans.filter((ts) => ts.id !== removedId),
-                                cursor: oldData.timeSpans.cursor,
-                            },
-                        },
-                    });
-                }
-            },
-        });
+        const [removeTimeSpan] = useMutation<RemoveTimeSpan, RemoveTimeSpanVariables>(gqlTimeSpan.RemoveTimeSpan, removeTimeSpanOptions);
 
         const updateNote = (newValue: string) => {
             window.clearTimeout(note.current.handle);

--- a/ui/src/timespan/TimeSpan.tsx
+++ b/ui/src/timespan/TimeSpan.tsx
@@ -22,7 +22,7 @@ import {StartTimer, StartTimerVariables} from '../gql/__generated__/StartTimer';
 import {RelativeTime, RelativeToNow} from '../common/RelativeTime';
 import ShowNotesIcon from '@material-ui/icons/KeyboardArrowDown';
 import HideNotesIcon from '@material-ui/icons/KeyboardArrowUp';
-import {removeTimeSpanOptions} from "./mutations";
+import {removeTimeSpanOptions} from './mutations';
 
 interface Range {
     from: moment.Moment;
@@ -81,7 +81,10 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
             clearTimeout(note.current.handle);
             return updateTimeSpan({variables: {...variables, note: note.current.value}});
         };
-        const [removeTimeSpan] = useMutation<RemoveTimeSpan, RemoveTimeSpanVariables>(gqlTimeSpan.RemoveTimeSpan, removeTimeSpanOptions);
+        const [removeTimeSpan] = useMutation<RemoveTimeSpan, RemoveTimeSpanVariables>(
+            gqlTimeSpan.RemoveTimeSpan,
+            removeTimeSpanOptions
+        );
 
         const updateNote = (newValue: string) => {
             window.clearTimeout(note.current.handle);

--- a/ui/src/timespan/calendar/CalendarPage.tsx
+++ b/ui/src/timespan/calendar/CalendarPage.tsx
@@ -39,8 +39,8 @@ import {timeRunningCalendar} from '../timeutils';
 import {stripTypename} from '../../utils/strip';
 import {TimeSpansInRange, TimeSpansInRangeVariables} from '../../gql/__generated__/TimeSpansInRange';
 import {ExtendedEventSourceInput} from '@fullcalendar/core/structs/event-source';
-import {RemoveTimeSpan, RemoveTimeSpanVariables} from "../../gql/__generated__/RemoveTimeSpan";
-import {removeTimeSpanOptions} from "../mutations";
+import {RemoveTimeSpan, RemoveTimeSpanVariables} from '../../gql/__generated__/RemoveTimeSpan';
+import {removeTimeSpanOptions} from '../mutations';
 
 const toMoment = (date: Date): moment.Moment => {
     return moment(date).tz('utc');
@@ -75,7 +75,10 @@ export const CalendarPage: React.FC = () => {
         refetchQueries: [{query: gqlTimeSpan.Trackers}],
     });
     const [updateTimeSpanMutation] = useMutation<UpdateTimeSpan, UpdateTimeSpanVariables>(gqlTimeSpan.UpdateTimeSpan);
-    const [removeTimeSpan] = useMutation<RemoveTimeSpan, RemoveTimeSpanVariables>(gqlTimeSpan.RemoveTimeSpan, removeTimeSpanOptions);
+    const [removeTimeSpan] = useMutation<RemoveTimeSpan, RemoveTimeSpanVariables>(
+        gqlTimeSpan.RemoveTimeSpan,
+        removeTimeSpanOptions
+    );
     const [currentDate, setCurrentDate] = React.useState(moment());
     const [stopTimer] = useMutation<StopTimer, StopTimerVariables>(gqlTimeSpan.StopTimer, {
         update: (cache, {data}) => {
@@ -98,16 +101,16 @@ export const CalendarPage: React.FC = () => {
         return () => (window.__TRAGGO_CALENDAR = undefined);
     });
 
-    const fullCalendarRef = React.useRef<FullCalendar | null>(null)
+    const fullCalendarRef = React.useRef<FullCalendar | null>(null);
     const unselect = () => {
-        const instance = fullCalendarRef.current
+        const instance = fullCalendarRef.current;
         if (instance) {
-            const calendar = instance.getApi()
+            const calendar = instance.getApi();
             if (calendar) {
-                calendar.unselect()
+                calendar.unselect();
             }
         }
-    }
+    };
 
     const [ignore, setIgnore] = React.useState<boolean>(false);
     const [selected, setSelected] = React.useState<{selected: HTMLElement | null; data: TimeSpans_timeSpans_timeSpans | null}>({
@@ -115,7 +118,7 @@ export const CalendarPage: React.FC = () => {
         data: null,
     });
 
-    const [lastCreatedTimeSpanId, setLastCreatedTimeSpanId] = React.useState<number | null>(null)
+    const [lastCreatedTimeSpanId, setLastCreatedTimeSpanId] = React.useState<number | null>(null);
 
     const [addTimeSpan] = useMutation<AddTimeSpan, AddTimeSpanVariables>(gqlTimeSpan.AddTimeSpan, {
         update: (cache, {data}) => {
@@ -124,7 +127,7 @@ export const CalendarPage: React.FC = () => {
             }
             addTimeSpanInRangeToCache(cache, data.createTimeSpan, timeSpansResult.variables);
             addTimeSpanToCache(cache, data.createTimeSpan);
-            unselect()
+            unselect();
         },
     });
 
@@ -208,7 +211,7 @@ export const CalendarPage: React.FC = () => {
 
         if (result.data) {
             if (result.data.createTimeSpan) {
-                setLastCreatedTimeSpanId(result.data.createTimeSpan.id)
+                setLastCreatedTimeSpanId(result.data.createTimeSpan.id);
             }
         }
     };
@@ -223,7 +226,7 @@ export const CalendarPage: React.FC = () => {
 
         // tslint:disable-next-line:no-any
         setSelected({data: data.event.extendedProps.ts, selected: data.jsEvent.target as any});
-        setLastCreatedTimeSpanId(null)
+        setLastCreatedTimeSpanId(null);
     };
     if (trackersResult.data && !(trackersResult.data.timers || []).length) {
         const startTimerEvent: ExtendedEventSourceInput = {
@@ -239,58 +242,57 @@ export const CalendarPage: React.FC = () => {
     }
 
     useEffect(() => {
-
         if (selected.selected) {
-            console.log(selected)
+            console.log(selected);
         }
 
-        let deletingSelected = false
+        let deletingSelected = false;
 
         const onKeyDown = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
-                e.preventDefault()
+                e.preventDefault();
                 setSelected({selected: null, data: null});
-                unselect()
+                unselect();
             }
 
             if (lastCreatedTimeSpanId) {
                 if (e.key === 'Delete' || e.key === 'Backspace' || e.key === 'Escape') {
-                    e.preventDefault()
+                    e.preventDefault();
                     removeFromTimeSpanInRangeCache(apollo.cache, lastCreatedTimeSpanId, timeSpansResult.variables);
                     removeTimeSpan({variables: {id: lastCreatedTimeSpanId}}).finally(() => {
-                        deletingSelected = false
+                        deletingSelected = false;
                     });
-                    setSelected({selected: null, data: null})
-                    setLastCreatedTimeSpanId(null)
-                    unselect()
-                    return
+                    setSelected({selected: null, data: null});
+                    setLastCreatedTimeSpanId(null);
+                    unselect();
+                    return;
                 }
             }
 
             if (selected.data) {
-                if (e.key === 'Delete' || e.key === "Backspace" && !deletingSelected) {
-                    e.preventDefault()
+                if (e.key === 'Delete' || (e.key === 'Backspace' && !deletingSelected)) {
+                    e.preventDefault();
                     setSelected({selected: null, data: selected.data});
                     removeFromTimeSpanInRangeCache(apollo.cache, selected.data.id, timeSpansResult.variables);
                     removeTimeSpan({variables: {id: selected.data.id}}).finally(() => {
-                        deletingSelected = false
+                        deletingSelected = false;
                     });
                     setSelected({selected: null, data: null});
-                    unselect()
+                    unselect();
 
                     // FullCalendar.
                     // setTimeSpanSelectable(false)
-                    return
+                    return;
                 }
             }
-        }
+        };
 
-        document.addEventListener('keydown', onKeyDown)
+        document.addEventListener('keydown', onKeyDown);
 
         return () => {
-            document.removeEventListener('keydown', onKeyDown)
-        }
-    }, [selected, lastCreatedTimeSpanId])
+            document.removeEventListener('keydown', onKeyDown);
+        };
+    }, [selected, lastCreatedTimeSpanId]);
 
     return (
         <Paper style={{padding: 10, bottom: 10, top: 80, position: 'absolute'}} color="red">

--- a/ui/src/timespan/calendar/CalendarPage.tsx
+++ b/ui/src/timespan/calendar/CalendarPage.tsx
@@ -223,6 +223,7 @@ export const CalendarPage: React.FC = () => {
 
         // tslint:disable-next-line:no-any
         setSelected({data: data.event.extendedProps.ts, selected: data.jsEvent.target as any});
+        setLastCreatedTimeSpanId(null)
     };
     if (trackersResult.data && !(trackersResult.data.timers || []).length) {
         const startTimerEvent: ExtendedEventSourceInput = {
@@ -250,11 +251,10 @@ export const CalendarPage: React.FC = () => {
                 e.preventDefault()
                 setSelected({selected: null, data: null});
                 unselect()
-                return
             }
 
             if (lastCreatedTimeSpanId) {
-                if (e.key === 'Delete' || e.key === 'Backspace') {
+                if (e.key === 'Delete' || e.key === 'Backspace' || e.key === 'Escape') {
                     e.preventDefault()
                     removeFromTimeSpanInRangeCache(apollo.cache, lastCreatedTimeSpanId, timeSpansResult.variables);
                     removeTimeSpan({variables: {id: lastCreatedTimeSpanId}}).finally(() => {
@@ -263,7 +263,6 @@ export const CalendarPage: React.FC = () => {
                     setSelected({selected: null, data: null})
                     setLastCreatedTimeSpanId(null)
                     unselect()
-
                     return
                 }
             }

--- a/ui/src/timespan/calendar/CalendarPage.tsx
+++ b/ui/src/timespan/calendar/CalendarPage.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import {useEffect} from 'react';
 import {Paper, useTheme} from '@material-ui/core';
 import moment from 'moment';
 import {useApolloClient, useMutation, useQuery} from '@apollo/react-hooks';
@@ -239,7 +238,7 @@ export const CalendarPage: React.FC = () => {
         values.push(startTimerEvent);
     }
 
-    useEffect(() => {
+    React.useEffect(() => {
         let deletingSelected = false;
 
         const onKeyDown = (e: KeyboardEvent) => {
@@ -249,7 +248,11 @@ export const CalendarPage: React.FC = () => {
                 unselectCalenderItem();
             }
 
-            if (!deletingSelected && lastCreatedTimeSpanId && (e.key === 'Delete' || e.key === 'Backspace' || e.key === 'Escape')) {
+            if (
+                !deletingSelected &&
+                lastCreatedTimeSpanId &&
+                (e.key === 'Delete' || e.key === 'Backspace' || e.key === 'Escape')
+            ) {
                 e.preventDefault();
                 removeFromTimeSpanInRangeCache(apollo.cache, lastCreatedTimeSpanId, timeSpansResult.variables);
                 removeTimeSpan({variables: {id: lastCreatedTimeSpanId}}).finally(() => {
@@ -261,7 +264,7 @@ export const CalendarPage: React.FC = () => {
                 return;
             }
 
-            if (selected.data && (e.key === 'Delete' || (e.key === 'Backspace') && !deletingSelected)) {
+            if (!deletingSelected && selected.data && (e.key === 'Delete' || e.key === 'Backspace')) {
                 e.preventDefault();
                 setSelected({selected: null, data: selected.data});
                 removeFromTimeSpanInRangeCache(apollo.cache, selected.data.id, timeSpansResult.variables);

--- a/ui/src/timespan/mutations.ts
+++ b/ui/src/timespan/mutations.ts
@@ -1,8 +1,8 @@
-import {RemoveTimeSpan, RemoveTimeSpanVariables} from "../gql/__generated__/RemoveTimeSpan";
-import * as gqlTimeSpan from "../gql/timeSpan";
-import {TimeSpans} from "../gql/__generated__/TimeSpans";
-import {Trackers} from "../gql/__generated__/Trackers";
-import {MutationHookOptions} from "@apollo/react-hooks/lib/types";
+import {RemoveTimeSpan, RemoveTimeSpanVariables} from '../gql/__generated__/RemoveTimeSpan';
+import * as gqlTimeSpan from '../gql/timeSpan';
+import {TimeSpans} from '../gql/__generated__/TimeSpans';
+import {Trackers} from '../gql/__generated__/Trackers';
+import {MutationHookOptions} from '@apollo/react-hooks/lib/types';
 
 export const removeTimeSpanOptions: MutationHookOptions<RemoveTimeSpan, RemoveTimeSpanVariables> = {
     update: (cache, {data}) => {
@@ -37,4 +37,4 @@ export const removeTimeSpanOptions: MutationHookOptions<RemoveTimeSpan, RemoveTi
             });
         }
     },
-}
+};

--- a/ui/src/timespan/mutations.ts
+++ b/ui/src/timespan/mutations.ts
@@ -1,0 +1,40 @@
+import {RemoveTimeSpan, RemoveTimeSpanVariables} from "../gql/__generated__/RemoveTimeSpan";
+import * as gqlTimeSpan from "../gql/timeSpan";
+import {TimeSpans} from "../gql/__generated__/TimeSpans";
+import {Trackers} from "../gql/__generated__/Trackers";
+import {MutationHookOptions} from "@apollo/react-hooks/lib/types";
+
+export const removeTimeSpanOptions: MutationHookOptions<RemoveTimeSpan, RemoveTimeSpanVariables> = {
+    update: (cache, {data}) => {
+        let oldData: TimeSpans | null = null;
+        try {
+            oldData = cache.readQuery<TimeSpans>({query: gqlTimeSpan.TimeSpans});
+        } catch (e) {}
+
+        const oldTrackers = cache.readQuery<Trackers>({query: gqlTimeSpan.Trackers});
+        if (!data || !data.removeTimeSpan) {
+            return;
+        }
+        const removedId = data.removeTimeSpan.id;
+        if (oldTrackers) {
+            cache.writeQuery<Trackers>({
+                query: gqlTimeSpan.Trackers,
+                data: {
+                    timers: (oldTrackers.timers || []).filter((tracker) => tracker.id !== removedId),
+                },
+            });
+        }
+        if (oldData) {
+            cache.writeQuery<TimeSpans>({
+                query: gqlTimeSpan.TimeSpans,
+                data: {
+                    timeSpans: {
+                        __typename: 'PagedTimeSpans',
+                        timeSpans: oldData.timeSpans.timeSpans.filter((ts) => ts.id !== removedId),
+                        cursor: oldData.timeSpans.cursor,
+                    },
+                },
+            });
+        }
+    },
+}


### PR DESCRIPTION
Added hotkeys for deleting timespans.

Selecting a timespan and pressing delete or backspace will delete it.
Pressing escape will unselect.

Pressing escape after creating a new timespan will delete the newly created timespan until it or another timespan has been selected. Side note: I think it would be preferred to set newly created timespans as selected and open the popper menu for tagging and whatnot and this side case would no longer be necessary as just pressing delete and backspace / the trash icon would feel more natural. But... I can't figure out how to get that to work and without it, this feels pretty good.
