### PR TITLE
fix: favicon path prefix

### DIFF
--- a/ui/serve.go
+++ b/ui/serve.go
@@ -27,7 +27,7 @@ func Register(r *mux.Router) {
 	r.Handle("/favicon.ico", serveFile("favicon.ico", "image/x-icon"))
 	for _, size := range []string{"16x16", "32x32", "192x192", "256x256"} {
 		fileName := fmt.Sprintf("favicon-%s.png", size)
-		r.Handle(fileName, serveFile(fileName, "image/png"))
+		r.Handle("/" + fileName, serveFile(fileName, "image/png"))
 	}
 }
 


### PR DESCRIPTION
Hi there,
I noticed that the favicon is missing after installing traggo.
It looks like due to the missing "/" prefix all the favicons (except favicon.ico) result in a 404.

I'm a GO newbie, so please double-check this.
Thank you!