### PR TITLE
Forced seconds to 0 when time updated in List view

### DIFF
--- a/timespan/update.go
+++ b/timespan/update.go
@@ -12,17 +12,31 @@ import (
 
 // UpdateTimeSpan update a time span
 func (r *ResolverForTimeSpan) UpdateTimeSpan(ctx context.Context, id int, start model.Time, end *model.Time, tags []*gqlmodel.InputTimeSpanTag, oldStart *model.Time, note string) (*gqlmodel.TimeSpan, error) {
-	timeSpan, err := timespanToInternal(auth.GetUser(ctx).ID, start, end, tags, note)
-	if err != nil {
-		return nil, err
+	// Setting the seconds to 0 when a change comes in, to not have 'wrong' Calculations
+	var timeSpan model.TimeSpan
+	var err error
+	incStart := start.Time().Local()
+	fmt.Println(time.Time.Location(incStart))
+	fixedStart := model.Time(time.Date(incStart.Year(), incStart.Month(), incStart.Day(), incStart.Hour(), incStart.Minute(), 0, 0, time.Local))
+	if end != nil {
+		incEnd := end.Time().Local()
+		fixedEnd := model.Time(time.Date(incEnd.Year(), incEnd.Month(), incEnd.Day(), incEnd.Hour(), incEnd.Minute(), 0, 0, time.Local))
+		timeSpan, err = timespanToInternal(auth.GetUser(ctx).ID, fixedStart, &fixedEnd, tags, note)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		timeSpan, err = timespanToInternal(auth.GetUser(ctx).ID, fixedStart, end, tags, note) // end == nil
+		if err != nil {
+			return nil, err
+		}
 	}
-
 	oldTimeSpan := model.TimeSpan{ID: id}
 	if r.DB.Where("user_id = ?", auth.GetUser(ctx).ID).Find(&oldTimeSpan).RecordNotFound() {
 		return nil, fmt.Errorf("time span with id %d does not exist", id)
 	}
 
-	if err := tagsExist(r.DB, auth.GetUser(ctx).ID, timeSpan.Tags); err != nil {
+	if err = tagsExist(r.DB, auth.GetUser(ctx).ID, timeSpan.Tags); err != nil {
 		return nil, err
 	}
 

--- a/timespan/update.go
+++ b/timespan/update.go
@@ -12,25 +12,11 @@ import (
 
 // UpdateTimeSpan update a time span
 func (r *ResolverForTimeSpan) UpdateTimeSpan(ctx context.Context, id int, start model.Time, end *model.Time, tags []*gqlmodel.InputTimeSpanTag, oldStart *model.Time, note string) (*gqlmodel.TimeSpan, error) {
-	// Setting the seconds to 0 when a change comes in, to not have 'wrong' Calculations
-	var timeSpan model.TimeSpan
-	var err error
-	incStart := start.Time().Local()
-	fmt.Println(time.Time.Location(incStart))
-	fixedStart := model.Time(time.Date(incStart.Year(), incStart.Month(), incStart.Day(), incStart.Hour(), incStart.Minute(), 0, 0, time.Local))
-	if end != nil {
-		incEnd := end.Time().Local()
-		fixedEnd := model.Time(time.Date(incEnd.Year(), incEnd.Month(), incEnd.Day(), incEnd.Hour(), incEnd.Minute(), 0, 0, time.Local))
-		timeSpan, err = timespanToInternal(auth.GetUser(ctx).ID, fixedStart, &fixedEnd, tags, note)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		timeSpan, err = timespanToInternal(auth.GetUser(ctx).ID, fixedStart, end, tags, note) // end == nil
-		if err != nil {
-			return nil, err
-		}
+	timeSpan, err := timespanToInternal(auth.GetUser(ctx).ID, start, end, tags, note) // end == nil
+	if err != nil {
+		return nil, err
 	}
+	
 	oldTimeSpan := model.TimeSpan{ID: id}
 	if r.DB.Where("user_id = ?", auth.GetUser(ctx).ID).Find(&oldTimeSpan).RecordNotFound() {
 		return nil, fmt.Errorf("time span with id %d does not exist", id)

--- a/ui/src/timespan/TimeSpan.tsx
+++ b/ui/src/timespan/TimeSpan.tsx
@@ -125,8 +125,8 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
                         variables: {
                             oldStart: oldFrom,
                             id,
-                            start: inUserTz(from).format(),
-                            end: to && inUserTz(to).format(),
+                            start: inUserTz(from).set({seconds: 0}).format(),
+                            end: to && inUserTz(to).set({seconds: 0}).format(),
                             tags: toInputTags(selectedEntries),
                             note: newValue,
                         },
@@ -168,8 +168,8 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
                                     variables: {
                                         oldStart: oldFrom,
                                         id,
-                                        start: inUserTz(from).format(),
-                                        end: to && inUserTz(to).format(),
+                                        start: inUserTz(from.set({seconds: 0})).format(),
+                                        end: to && inUserTz(to.set({seconds: 0})).format(),
                                         tags: toInputTags(entries),
                                     },
                                 });
@@ -183,14 +183,15 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
                             if (!newFrom.isValid()) {
                                 return;
                             }
-                            if (to && moment(newFrom).isAfter(to)) {
-                                const newTo = moment(newFrom).add(15, 'minute');
+                            newFrom = newFrom.set({seconds: 0})
+                            if (to && moment(newFrom).set({seconds: 0}).isAfter(to)) {
+                                var newTo = moment(newFrom).add(15, 'minute');
                                 noteAwareUpdateTimeSpan({
                                     variables: {
                                         oldStart: oldFrom,
                                         id,
                                         start: inUserTz(newFrom).format(),
-                                        end: inUserTz(newTo).format(),
+                                        end: inUserTz(newTo.set({seconds: 0})).format(),
                                         tags: toInputTags(selectedEntries),
                                     },
                                 }).then(() => rangeChange({from: newFrom, to: newTo}));
@@ -199,8 +200,8 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
                                     variables: {
                                         id,
                                         oldStart: oldFrom,
-                                        start: inUserTz(newFrom).format(),
-                                        end: to && inUserTz(to).format(),
+                                        start: inUserTz(from.set({seconds: 0})).format(),
+                                        end: to && inUserTz(to.set({seconds: 0})).format(),
                                         tags: toInputTags(selectedEntries),
                                     },
                                 }).then(() => rangeChange({from: newFrom, to}));
@@ -217,6 +218,7 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
                                 if (!newTo.isValid()) {
                                     return;
                                 }
+                                newTo = newTo.set({seconds: 0})
                                 if (moment(newTo).isBefore(from)) {
                                     const newFrom = moment(newTo).subtract(15, 'minute');
                                     noteAwareUpdateTimeSpan({
@@ -233,7 +235,7 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
                                         variables: {
                                             id,
                                             oldStart: oldFrom,
-                                            start: inUserTz(from).format(),
+                                            start: inUserTz(from.set({seconds: 0})).format(),
                                             end: inUserTz(newTo).format(),
                                             tags: toInputTags(selectedEntries),
                                         },

--- a/ui/src/timespan/Tracker.tsx
+++ b/ui/src/timespan/Tracker.tsx
@@ -95,7 +95,7 @@ export const Tracker: React.FC<TrackerProps> = ({selectedEntries, onSelectedEntr
                                 if (!newFrom.isValid()) {
                                     return;
                                 }
-                                setFrom(newFrom);
+                                setFrom(newFrom.set({"seconds":0}));
                                 if (moment(newFrom).isAfter(to)) {
                                     const newTo = moment(newFrom).add(15, 'minute');
                                     setTo(newTo);
@@ -113,7 +113,7 @@ export const Tracker: React.FC<TrackerProps> = ({selectedEntries, onSelectedEntr
                                 if (!newTo.isValid()) {
                                     return;
                                 }
-                                setTo(newTo);
+                                setTo(newTo.set({"seconds": 0}));
                                 if (moment(newTo).isBefore(from)) {
                                     const newFrom = moment(newTo).subtract(15, 'minute');
                                     setFrom(newFrom);

--- a/ui/src/timespan/calendar/CalendarPage.tsx
+++ b/ui/src/timespan/calendar/CalendarPage.tsx
@@ -156,8 +156,8 @@ export const CalendarPage: React.FC = () => {
         updateTimeSpanMutation({
             variables: {
                 oldStart: moment(data.oldEvent.start!).format(),
-                start: moment(data.event.start!).format(),
-                end: moment(data.event.end!).format(),
+                start: moment(data.event.start!).set({seconds: 0}).format(),
+                end: moment(data.event.end!).set({seconds: 0}).format(),
                 id: parseInt(data.event.id, 10),
                 tags: stripTypename(data.event.extendedProps.ts.tags),
                 note: data.event.extendedProps.ts.note,


### PR DESCRIPTION
Whenever the updateTimeSpan function is called, now will make the correct checks (for end == nil) and force the two new times to be times with seconds set to 00. 

Please let me know if the formatting etc. needs to be changed. 


I have tested with `go test ./...` as well as the Makefile and all tests from GO + UI passed. 

It also had the desired effect **(in my local testing)** that if I had a 25min or multiple therefore Interval it always counted correctly. 

This should close/fix #110 
