### PR TITLE
Prevent losing focus when pressing Escape

### DIFF
--- a/ui/src/tag/TagSelector.tsx
+++ b/ui/src/tag/TagSelector.tsx
@@ -132,7 +132,6 @@ export const TagSelector: React.FC<TagSelectorProps> = ({
         }
         if (event.key === 'Escape' && input.current) {
             event.preventDefault();
-            input.current.blur();
             setOpen(false);
         }
     };


### PR DESCRIPTION
You no longer lose focus when pressing Escape in the tag selector.