### PR TITLE
Calendar 5 days option

### DIFF
--- a/ui/src/timespan/calendar/CalendarPage.tsx
+++ b/ui/src/timespan/calendar/CalendarPage.tsx
@@ -226,6 +226,13 @@ export const CalendarPage: React.FC = () => {
                             timeSpansResult.refetch(range);
                         }
                     }}
+                    views = {{
+                        timeGrid5Day: {
+                            type: 'timeGrid',
+                            duration: { days: 5 },
+                            buttonText: '5 day'
+                        }
+                    }}
                     editable={true}
                     events={values}
                     allDaySlot={false}
@@ -263,7 +270,7 @@ export const CalendarPage: React.FC = () => {
                     header={{
                         center: 'title',
                         left: 'prev,next today',
-                        right: 'timeGridWeek,timeGridDay',
+                        right: 'timeGridWeek,timeGrid5Day,timeGridDay',
                     }}
                 />
             </FullCalendarStyling>

--- a/ui/src/timespan/calendar/CalendarPage.tsx
+++ b/ui/src/timespan/calendar/CalendarPage.tsx
@@ -229,8 +229,9 @@ export const CalendarPage: React.FC = () => {
                     views = {{
                         timeGrid5Day: {
                             type: 'timeGrid',
-                            duration: { days: 5 },
-                            buttonText: '5 day'
+                            duration: { days: 7 },
+                            buttonText: '5 day',
+                            hiddenDays: [0, 6]
                         }
                     }}
                     editable={true}

--- a/ui/src/timespan/calendar/CalendarPage.tsx
+++ b/ui/src/timespan/calendar/CalendarPage.tsx
@@ -226,13 +226,13 @@ export const CalendarPage: React.FC = () => {
                             timeSpansResult.refetch(range);
                         }
                     }}
-                    views = {{
+                    views={{
                         timeGrid5Day: {
                             type: 'timeGrid',
-                            duration: { days: 7 },
+                            duration: {days: 7},
                             buttonText: '5 day',
-                            hiddenDays: [0, 6]
-                        }
+                            hiddenDays: [0, 6],
+                        },
                     }}
                     editable={true}
                     events={values}


### PR DESCRIPTION
Aimed at #168, this isn't exactly 'weekdays only' but it does provide a button to limit the number of days shown to 5. 

I *think* once the week starts it will hopefully stay showing mon-fri, but maybe not. At the very least, this will provide a more manageable week view on mobile, since 7 days is hard to see anything.