### PR TITLE
Set org.opencontainers.image.source label in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
+LABEL org.opencontainers.image.source="https://github.com/traggo/server"
 WORKDIR /opt/traggo
 COPY traggo /opt/traggo
 EXPOSE 3030


### PR DESCRIPTION
As documented in the OCI Image Format, [org.opencontainers.image.source](https://github.com/opencontainers/image-spec/blob/5325ec48851022d6ded604199a3566254e72842a/annotations.md#L24) identifies an image's source repository. This is purely for documentation purposes. It does however help tools such as [Renovate](https://docs.renovatebot.com/modules/datasource/docker/#description) to find the changelogs when a new Traggo version is released. The changelogs would then be included in the PR Renovate creates.