### PR TITLE
Fix crash from reduce of empty array

### DIFF
--- a/ui/src/dashboard/Entry/DashboardEntry.tsx
+++ b/ui/src/dashboard/Entry/DashboardEntry.tsx
@@ -67,63 +67,29 @@ const SpecificDashboardEntry: React.FC<{entry: Dashboards_dashboards_items; rang
             </Center>
         );
     }
+    const firstEntries: Stats_stats_entries[] =
+        (stats.data && stats.data.stats && stats.data.stats[0] && stats.data.stats[0].entries) || [];
+    if (firstEntries.length === 0) {
+        return (
+            <Center>
+                <Typography>no data</Typography>
+            </Center>
+        );
+    }
 
     const entries = (stats.data && stats.data.stats) || [];
     switch (entry.entryType) {
         case EntryType.PieChart:
-            const data: Stats_stats_entries[] = (stats.data && stats.data.stats && stats.data.stats[0].entries) || [];
-            if (data.length === 0) {
-                return (
-                    <Center>
-                        <Typography>no data</Typography>
-                    </Center>
-                );
-            }
-            return <DashboardPieChart entries={data} />;
+            return <DashboardPieChart entries={firstEntries} />;
         case EntryType.BarChart:
-            if (entries.length === 0) {
-                return (
-                    <Center>
-                        <Typography>no data</Typography>
-                    </Center>
-                );
-            }
             return <DashboardBarChart entries={entries} interval={interval} type="normal" total={entry.total} />;
         case EntryType.StackedBarChart:
-            if (entries.length === 0) {
-                return (
-                    <Center>
-                        <Typography>no data</Typography>
-                    </Center>
-                );
-            }
             return <DashboardBarChart entries={entries} interval={interval} type="stacked" total={entry.total} />;
         case EntryType.LineChart:
-            if (entries.length === 0) {
-                return (
-                    <Center>
-                        <Typography>no data</Typography>
-                    </Center>
-                );
-            }
             return <DashboardLineChart entries={entries} interval={interval} total={entry.total} />;
         case EntryType.VerticalTable:
-            if (entries.length === 0) {
-                return (
-                    <Center>
-                        <Typography>no data</Typography>
-                    </Center>
-                );
-            }
             return <DashboardTable mode="vertical" entries={entries} interval={interval} total={entry.total} />;
         case EntryType.HorizontalTable:
-            if (entries.length === 0) {
-                return (
-                    <Center>
-                        <Typography>no data</Typography>
-                    </Center>
-                );
-            }
             return <DashboardTable mode="horizontal" entries={entries} interval={interval} total={entry.total} />;
         default:
             return expectNever(entry.entryType);

--- a/ui/src/dashboard/Entry/DashboardPieChart.tsx
+++ b/ui/src/dashboard/Entry/DashboardPieChart.tsx
@@ -48,7 +48,7 @@ const CustomTooltip = ({active, payload, total}: CustomTooltipProps) => {
             <Paper style={{padding: 10}} elevation={4}>
                 <Typography>
                     {first.payload.key}:{first.payload.value}: {prettyMs(first.payload.timeSpendInSeconds * 1000)} (
-                    {((first.payload.timeSpendInSeconds / total) * 100).toFixed(2)}%)
+                    {total > 0 ? ((first.payload.timeSpendInSeconds / total) * 100).toFixed(2) : '0.00'}%)
                 </Typography>
             </Paper>
         );

--- a/ui/src/dashboard/Entry/DashboardTable.tsx
+++ b/ui/src/dashboard/Entry/DashboardTable.tsx
@@ -31,7 +31,7 @@ export const DashboardTable: React.FC<DashboardTableProps> = ({entries, interval
                 }, {}),
             };
             if (total) {
-                result.data['Total'] = Object.values(result.data).reduce((acc, value) => acc + value);
+                result.data['Total'] = Object.values(result.data).reduce((acc, value) => acc + value, 0);
             }
             return result;
         })


### PR DESCRIPTION
One of my dashboard is failing because of the change of year. This fixes it. I also added a divide by 0 check in the % calculation on pie charts since I was thinking that was the problem at first.

```
TypeError: reduce of empty array with no initial value
./src/dashboard/Entry/DashboardTable.tsx/DashboardTable/indexedEntries<
src/dashboard/Entry/DashboardTable.tsx:34

  31 |         }, {}),
  32 |     };
  33 |     if (total) {
> 34 |         result.data['Total'] = Object.values(result.data).reduce((acc, value) => acc + value);
     | ^  35 |     }
  36 |     return result;
  37 | })
```