### PR TITLE
Add setting to use `<input type="datetime-local">` for datetime pickers

### DIFF
--- a/model/setting.go
+++ b/model/setting.go
@@ -4,10 +4,11 @@ import "time"
 
 // UserSetting a setting for a user.
 type UserSetting struct {
-	UserID            int `gorm:"primary_key;unique_index"`
-	Theme             string
-	DateLocale        string
-	FirstDayOfTheWeek string
+	UserID             int `gorm:"primary_key;unique_index"`
+	Theme              string
+	DateLocale         string
+	FirstDayOfTheWeek  string
+	DatetimeInputStyle string
 }
 
 // Settings constants
@@ -22,6 +23,9 @@ const (
 	DateLocaleAmerican24h = "American24h"
 	DateLocaleBritish     = "British"
 	DateLocaleAustralian  = "Australian"
+
+	DatetimeInputFancy    = "Fancy"
+	DatetimeInputStandard = "Standard"
 )
 
 var daysOfWeek = map[string]time.Weekday{

--- a/model/setting.go
+++ b/model/setting.go
@@ -24,8 +24,8 @@ const (
 	DateLocaleBritish     = "British"
 	DateLocaleAustralian  = "Australian"
 
-	DatetimeInputFancy    = "Fancy"
-	DatetimeInputStandard = "Standard"
+	DateTimeInputFancy  = "Fancy"
+	DateTimeInputNative = "Native"
 )
 
 var daysOfWeek = map[string]time.Weekday{

--- a/model/setting.go
+++ b/model/setting.go
@@ -8,7 +8,7 @@ type UserSetting struct {
 	Theme              string
 	DateLocale         string
 	FirstDayOfTheWeek  string
-	DatetimeInputStyle string
+	DateTimeInputStyle string
 }
 
 // Settings constants

--- a/schema.graphql
+++ b/schema.graphql
@@ -68,14 +68,14 @@ input InputUserSettings {
     theme: Theme!
     dateLocale: DateLocale!
     firstDayOfTheWeek: WeekDay!
-    datetimeInputStyle: DatetimeInputStyle!
+    dateTimeInputStyle: DateTimeInputStyle!
 }
 
 type UserSettings {
     theme: Theme!
     dateLocale: DateLocale!
     firstDayOfTheWeek: WeekDay!
-    datetimeInputStyle: DatetimeInputStyle!
+    dateTimeInputStyle: DateTimeInputStyle!
 }
 
 enum WeekDay {
@@ -90,7 +90,7 @@ enum DateLocale {
     American, American24h, German, Australian, British
 }
 
-enum DatetimeInputStyle {
+enum DateTimeInputStyle {
     Fancy, Native
 }
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -91,7 +91,7 @@ enum DateLocale {
 }
 
 enum DatetimeInputStyle {
-    Fancy, Standard
+    Fancy, Native
 }
 
 input InputReplaceOptions {

--- a/schema.graphql
+++ b/schema.graphql
@@ -68,12 +68,14 @@ input InputUserSettings {
     theme: Theme!
     dateLocale: DateLocale!
     firstDayOfTheWeek: WeekDay!
+    datetimeInputStyle: DatetimeInputStyle!
 }
 
 type UserSettings {
     theme: Theme!
     dateLocale: DateLocale!
     firstDayOfTheWeek: WeekDay!
+    datetimeInputStyle: DatetimeInputStyle!
 }
 
 enum WeekDay {
@@ -86,6 +88,10 @@ enum Theme {
 
 enum DateLocale {
     American, American24h, German, Australian, British
+}
+
+enum DatetimeInputStyle {
+    Fancy, Standard
 }
 
 input InputReplaceOptions {

--- a/setting/get.go
+++ b/setting/get.go
@@ -17,7 +17,7 @@ func Get(ctx context.Context, db *gorm.DB) (model.UserSetting, error) {
 		Theme:              model.ThemeGruvboxDark,
 		DateLocale:         model.DateLocaleAmerican,
 		FirstDayOfTheWeek:  time.Monday.String(),
-		DatetimeInputStyle: model.DatetimeInputFancy,
+		DateTimeInputStyle: model.DateTimeInputFancy,
 	}
 
 	if user == nil {

--- a/setting/get.go
+++ b/setting/get.go
@@ -14,9 +14,10 @@ func Get(ctx context.Context, db *gorm.DB) (model.UserSetting, error) {
 	internal := model.UserSetting{}
 	user := auth.GetUser(ctx)
 	defaultSettings := model.UserSetting{
-		Theme:             model.ThemeGruvboxDark,
-		DateLocale:        model.DateLocaleAmerican,
-		FirstDayOfTheWeek: time.Monday.String(),
+		Theme:              model.ThemeGruvboxDark,
+		DateLocale:         model.DateLocaleAmerican,
+		FirstDayOfTheWeek:  time.Monday.String(),
+		DatetimeInputStyle: model.DatetimeInputFancy,
 	}
 
 	if user == nil {

--- a/setting/usersettings.go
+++ b/setting/usersettings.go
@@ -12,10 +12,11 @@ import (
 // SetUserSettings sets the user settings.
 func (r *ResolverForSettings) SetUserSettings(ctx context.Context, settings gqlmodel.InputUserSettings) (*gqlmodel.UserSettings, error) {
 	internal := model.UserSetting{
-		Theme:             toInternalTheme(settings.Theme),
-		FirstDayOfTheWeek: toInternalWeekday(settings.FirstDayOfTheWeek).String(),
-		UserID:            auth.GetUser(ctx).ID,
-		DateLocale:        toInternalDateLocale(settings.DateLocale),
+		Theme:              toInternalTheme(settings.Theme),
+		FirstDayOfTheWeek:  toInternalWeekday(settings.FirstDayOfTheWeek).String(),
+		UserID:             auth.GetUser(ctx).ID,
+		DateLocale:         toInternalDateLocale(settings.DateLocale),
+		DatetimeInputStyle: toInternalDatetimeInputStyle(settings.DatetimeInputStyle),
 	}
 
 	save := r.DB.Save(internal)
@@ -31,9 +32,10 @@ func (r *ResolverForSettings) UserSettings(ctx context.Context) (*gqlmodel.UserS
 
 func toExternal(internal model.UserSetting) *gqlmodel.UserSettings {
 	return &gqlmodel.UserSettings{
-		Theme:             toExternalTheme(internal.Theme),
-		DateLocale:        toExternalDateLocale(internal.DateLocale),
-		FirstDayOfTheWeek: toExternalWeekday(internal.FirstDayOfTheWeekTimeWeekday()),
+		Theme:              toExternalTheme(internal.Theme),
+		DateLocale:         toExternalDateLocale(internal.DateLocale),
+		FirstDayOfTheWeek:  toExternalWeekday(internal.FirstDayOfTheWeekTimeWeekday()),
+		DatetimeInputStyle: toExternalDatetimeInputStyle(internal.DatetimeInputStyle),
 	}
 }
 
@@ -111,5 +113,27 @@ func toInternalWeekday(weekday gqlmodel.WeekDay) time.Weekday {
 		return time.Sunday
 	default:
 		panic("unknown weekday")
+	}
+}
+
+func toExternalDatetimeInputStyle(style string) gqlmodel.DatetimeInputStyle {
+	switch style {
+	case model.DatetimeInputFancy:
+		return model.DatetimeInputFancy
+	case model.DatetimeInputStandard:
+		return model.DatetimeInputStandard
+	default:
+		panic("unknown datetime input style")
+	}
+}
+
+func toInternalDatetimeInputStyle(style gqlmodel.DatetimeInputStyle) string {
+	switch style {
+	case gqlmodel.DatetimeInputStyleFancy:
+		return model.DatetimeInputFancy
+	case gqlmodel.DatetimeInputStyleStandard:
+		return model.DatetimeInputStandard
+	default:
+		panic("unknown datetime input style")
 	}
 }

--- a/setting/usersettings.go
+++ b/setting/usersettings.go
@@ -16,7 +16,7 @@ func (r *ResolverForSettings) SetUserSettings(ctx context.Context, settings gqlm
 		FirstDayOfTheWeek:  toInternalWeekday(settings.FirstDayOfTheWeek).String(),
 		UserID:             auth.GetUser(ctx).ID,
 		DateLocale:         toInternalDateLocale(settings.DateLocale),
-		DatetimeInputStyle: toInternalDatetimeInputStyle(settings.DatetimeInputStyle),
+		DateTimeInputStyle: toInternalDateTimeInputStyle(settings.DateTimeInputStyle),
 	}
 
 	save := r.DB.Save(internal)
@@ -35,7 +35,7 @@ func toExternal(internal model.UserSetting) *gqlmodel.UserSettings {
 		Theme:              toExternalTheme(internal.Theme),
 		DateLocale:         toExternalDateLocale(internal.DateLocale),
 		FirstDayOfTheWeek:  toExternalWeekday(internal.FirstDayOfTheWeekTimeWeekday()),
-		DatetimeInputStyle: toExternalDatetimeInputStyle(internal.DatetimeInputStyle),
+		DateTimeInputStyle: toExternalDateTimeInputStyle(internal.DateTimeInputStyle),
 	}
 }
 
@@ -116,23 +116,23 @@ func toInternalWeekday(weekday gqlmodel.WeekDay) time.Weekday {
 	}
 }
 
-func toExternalDatetimeInputStyle(style string) gqlmodel.DatetimeInputStyle {
+func toExternalDateTimeInputStyle(style string) gqlmodel.DateTimeInputStyle {
 	switch style {
-	case model.DatetimeInputFancy:
-		return model.DatetimeInputFancy
-	case model.DatetimeInputNative:
-		return model.DatetimeInputNative
+	case model.DateTimeInputFancy:
+		return model.DateTimeInputFancy
+	case model.DateTimeInputNative:
+		return model.DateTimeInputNative
 	default:
 		panic("unknown datetime input style")
 	}
 }
 
-func toInternalDatetimeInputStyle(style gqlmodel.DatetimeInputStyle) string {
+func toInternalDateTimeInputStyle(style gqlmodel.DateTimeInputStyle) string {
 	switch style {
-	case gqlmodel.DatetimeInputStyleFancy:
-		return model.DatetimeInputFancy
-	case gqlmodel.DatetimeInputStyleNative:
-		return model.DatetimeInputNative
+	case gqlmodel.DateTimeInputStyleFancy:
+		return model.DateTimeInputFancy
+	case gqlmodel.DateTimeInputStyleNative:
+		return model.DateTimeInputNative
 	default:
 		panic("unknown datetime input style")
 	}

--- a/setting/usersettings.go
+++ b/setting/usersettings.go
@@ -120,8 +120,8 @@ func toExternalDatetimeInputStyle(style string) gqlmodel.DatetimeInputStyle {
 	switch style {
 	case model.DatetimeInputFancy:
 		return model.DatetimeInputFancy
-	case model.DatetimeInputStandard:
-		return model.DatetimeInputStandard
+	case model.DatetimeInputNative:
+		return model.DatetimeInputNative
 	default:
 		panic("unknown datetime input style")
 	}
@@ -131,8 +131,8 @@ func toInternalDatetimeInputStyle(style gqlmodel.DatetimeInputStyle) string {
 	switch style {
 	case gqlmodel.DatetimeInputStyleFancy:
 		return model.DatetimeInputFancy
-	case gqlmodel.DatetimeInputStyleStandard:
-		return model.DatetimeInputStandard
+	case gqlmodel.DatetimeInputStyleNative:
+		return model.DatetimeInputNative
 	default:
 		panic("unknown datetime input style")
 	}

--- a/setting/usersettings_test.go
+++ b/setting/usersettings_test.go
@@ -31,7 +31,7 @@ func TestSettingsResolver(t *testing.T) {
 		Theme:              gqlmodel.ThemeGruvboxLight,
 		DateLocale:         gqlmodel.DateLocaleGerman,
 		FirstDayOfTheWeek:  gqlmodel.WeekDayWednesday,
-		DatetimeInputStyle: gqlmodel.DatetimeInputStyleFancy,
+		DateTimeInputStyle: gqlmodel.DateTimeInputStyleFancy,
 	})
 	require.NoError(t, err)
 
@@ -41,7 +41,7 @@ func TestSettingsResolver(t *testing.T) {
 		Theme:              gqlmodel.ThemeGruvboxLight,
 		DateLocale:         gqlmodel.DateLocaleGerman,
 		FirstDayOfTheWeek:  gqlmodel.WeekDayWednesday,
-		DatetimeInputStyle: gqlmodel.DatetimeInputStyleFancy,
+		DateTimeInputStyle: gqlmodel.DateTimeInputStyleFancy,
 	}, settings)
 }
 

--- a/setting/usersettings_test.go
+++ b/setting/usersettings_test.go
@@ -28,18 +28,20 @@ func TestSettingsResolver(t *testing.T) {
 	require.Equal(t, gqlmodel.ThemeGruvboxDark, settings.Theme)
 
 	_, err = resolver.SetUserSettings(fake.User(1), gqlmodel.InputUserSettings{
-		Theme:             gqlmodel.ThemeGruvboxLight,
-		DateLocale:        gqlmodel.DateLocaleGerman,
-		FirstDayOfTheWeek: gqlmodel.WeekDayWednesday,
+		Theme:              gqlmodel.ThemeGruvboxLight,
+		DateLocale:         gqlmodel.DateLocaleGerman,
+		FirstDayOfTheWeek:  gqlmodel.WeekDayWednesday,
+		DatetimeInputStyle: gqlmodel.DatetimeInputStyleFancy,
 	})
 	require.NoError(t, err)
 
 	settings, err = resolver.UserSettings(fake.User(1))
 	require.NoError(t, err)
 	require.Equal(t, &gqlmodel.UserSettings{
-		Theme:             gqlmodel.ThemeGruvboxLight,
-		DateLocale:        gqlmodel.DateLocaleGerman,
-		FirstDayOfTheWeek: gqlmodel.WeekDayWednesday,
+		Theme:              gqlmodel.ThemeGruvboxLight,
+		DateLocale:         gqlmodel.DateLocaleGerman,
+		FirstDayOfTheWeek:  gqlmodel.WeekDayWednesday,
+		DatetimeInputStyle: gqlmodel.DatetimeInputStyleFancy,
 	}, settings)
 }
 

--- a/tag/suggest_test.go
+++ b/tag/suggest_test.go
@@ -42,6 +42,6 @@ func TestGQL_SuggestTag_noMatchingTags(t *testing.T) {
 	tags, err := resolver.SuggestTag(fake.User(1), "fire")
 
 	require.Nil(t, err)
-    expected := []*gqlmodel.TagDefinition{}
+	expected := []*gqlmodel.TagDefinition{}
 	require.Equal(t, expected, tags)
 }

--- a/ui/serve.go
+++ b/ui/serve.go
@@ -27,7 +27,7 @@ func Register(r *mux.Router) {
 	r.Handle("/favicon.ico", serveFile("favicon.ico", "image/x-icon"))
 	for _, size := range []string{"16x16", "32x32", "192x192", "256x256"} {
 		fileName := fmt.Sprintf("favicon-%s.png", size)
-		r.Handle("/" + fileName, serveFile(fileName, "image/png"))
+		r.Handle("/"+fileName, serveFile(fileName, "image/png"))
 	}
 }
 

--- a/ui/src/common/DateTimeSelector.tsx
+++ b/ui/src/common/DateTimeSelector.tsx
@@ -21,7 +21,7 @@ export const DateTimeSelector: React.FC<DateTimeSelectorProps> = React.memo(
             return <span>...</span>;
         }
 
-        if (datetimeInputStyle === DatetimeInputStyle.Standard) {
+        if (datetimeInputStyle === DatetimeInputStyle.Native) {
             return (
                 <input
                     type="datetime-local"

--- a/ui/src/common/DateTimeSelector.tsx
+++ b/ui/src/common/DateTimeSelector.tsx
@@ -2,6 +2,8 @@ import * as React from 'react';
 import {KeyboardDateTimePicker} from '@material-ui/pickers';
 import * as moment from 'moment';
 import {uglyConvertToLocalTime} from '../timespan/timeutils';
+import {useSettings} from '../gql/settings';
+import {DatetimeInputStyle} from '../gql/__generated__/globalTypes';
 
 interface DateTimeSelectorProps {
     selectedDate: moment.Moment;
@@ -13,6 +15,29 @@ interface DateTimeSelectorProps {
 
 export const DateTimeSelector: React.FC<DateTimeSelectorProps> = React.memo(
     ({selectedDate, onSelectDate, showDate, label, popoverOpen = () => {}}) => {
+        const {done, datetimeInputStyle} = useSettings();
+
+        if (!done) {
+            return <span>...</span>;
+        }
+
+        if (datetimeInputStyle === DatetimeInputStyle.Standard) {
+            const formatDate = (d: Date): string => {
+                return [d.getFullYear(), '-', d.getMonth(), '-', d.getDay(), 'T', d.getHours(), ':', d.getMinutes()]
+                    .map((i) => (typeof i === 'number' ? i.toString().padStart(2, '0') : i))
+                    .join('');
+            };
+            return (
+                <input
+                    type="datetime-local"
+                    value={formatDate(selectedDate.toDate())}
+                    onChange={(e) => {
+                        onSelectDate(moment.default(e.target.value));
+                    }}
+                />
+            );
+        }
+
         const [open, setOpen] = React.useState(false);
         const localeData = moment.localeData();
         const time = localeData.longDateFormat('LT').replace('A', 'a');

--- a/ui/src/common/DateTimeSelector.tsx
+++ b/ui/src/common/DateTimeSelector.tsx
@@ -3,7 +3,7 @@ import {KeyboardDateTimePicker} from '@material-ui/pickers';
 import * as moment from 'moment';
 import {uglyConvertToLocalTime} from '../timespan/timeutils';
 import {useSettings} from '../gql/settings';
-import {DatetimeInputStyle} from '../gql/__generated__/globalTypes';
+import {DateTimeInputStyle} from '../gql/__generated__/globalTypes';
 
 interface DateTimeSelectorProps {
     selectedDate: moment.Moment;
@@ -15,13 +15,13 @@ interface DateTimeSelectorProps {
 
 export const DateTimeSelector: React.FC<DateTimeSelectorProps> = React.memo(
     ({selectedDate, onSelectDate, showDate, label, popoverOpen = () => {}}) => {
-        const {done, datetimeInputStyle} = useSettings();
+        const {done, dateTimeInputStyle} = useSettings();
 
         if (!done) {
             return <span>...</span>;
         }
 
-        if (datetimeInputStyle === DatetimeInputStyle.Native) {
+        if (dateTimeInputStyle === DateTimeInputStyle.Native) {
             return (
                 <input
                     type="datetime-local"

--- a/ui/src/common/DateTimeSelector.tsx
+++ b/ui/src/common/DateTimeSelector.tsx
@@ -22,15 +22,10 @@ export const DateTimeSelector: React.FC<DateTimeSelectorProps> = React.memo(
         }
 
         if (datetimeInputStyle === DatetimeInputStyle.Standard) {
-            const formatDate = (d: Date): string => {
-                return [d.getFullYear(), '-', d.getMonth(), '-', d.getDay(), 'T', d.getHours(), ':', d.getMinutes()]
-                    .map((i) => (typeof i === 'number' ? i.toString().padStart(2, '0') : i))
-                    .join('');
-            };
             return (
                 <input
                     type="datetime-local"
-                    value={formatDate(selectedDate.toDate())}
+                    value={selectedDate.format(selectedDate.format('YYYY-MM-DDTHH:mm'))}
                     onChange={(e) => {
                         onSelectDate(moment.default(e.target.value));
                     }}

--- a/ui/src/gql/settings.ts
+++ b/ui/src/gql/settings.ts
@@ -1,7 +1,7 @@
 import {gql} from 'apollo-boost';
 import {useQuery} from '@apollo/react-hooks';
 import {Settings as SettingsQueryResponse} from './__generated__/Settings';
-import {DateLocale, Theme, WeekDay} from './__generated__/globalTypes';
+import {DateLocale, Theme, WeekDay, DatetimeInputStyle} from './__generated__/globalTypes';
 import {stripTypename} from '../utils/strip';
 
 export const Settings = gql`
@@ -10,6 +10,7 @@ export const Settings = gql`
             theme
             dateLocale
             firstDayOfTheWeek
+            datetimeInputStyle
         }
     }
 `;
@@ -18,6 +19,7 @@ export const SetSettings = gql`
     mutation SetSettings($settings: InputUserSettings!) {
         setUserSettings(settings: $settings) {
             theme
+            datetimeInputStyle
         }
     }
 `;
@@ -26,6 +28,7 @@ const defaultSettings = {
     theme: Theme.GruvboxDark,
     dateLocale: DateLocale.American,
     firstDayOfTheWeek: WeekDay.Monday,
+    datetimeInputStyle: DatetimeInputStyle.Fancy,
 } as const;
 
 export const useSettings = (): {done: boolean} & Omit<SettingsQueryResponse['userSettings'], '__typename'> => {

--- a/ui/src/gql/settings.ts
+++ b/ui/src/gql/settings.ts
@@ -1,7 +1,7 @@
 import {gql} from 'apollo-boost';
 import {useQuery} from '@apollo/react-hooks';
 import {Settings as SettingsQueryResponse} from './__generated__/Settings';
-import {DateLocale, Theme, WeekDay, DatetimeInputStyle} from './__generated__/globalTypes';
+import {DateLocale, Theme, WeekDay, DateTimeInputStyle} from './__generated__/globalTypes';
 import {stripTypename} from '../utils/strip';
 
 export const Settings = gql`
@@ -10,7 +10,7 @@ export const Settings = gql`
             theme
             dateLocale
             firstDayOfTheWeek
-            datetimeInputStyle
+            dateTimeInputStyle
         }
     }
 `;
@@ -19,7 +19,7 @@ export const SetSettings = gql`
     mutation SetSettings($settings: InputUserSettings!) {
         setUserSettings(settings: $settings) {
             theme
-            datetimeInputStyle
+            dateTimeInputStyle
         }
     }
 `;
@@ -28,7 +28,7 @@ const defaultSettings = {
     theme: Theme.GruvboxDark,
     dateLocale: DateLocale.American,
     firstDayOfTheWeek: WeekDay.Monday,
-    datetimeInputStyle: DatetimeInputStyle.Fancy,
+    dateTimeInputStyle: DateTimeInputStyle.Fancy,
 } as const;
 
 export const useSettings = (): {done: boolean} & Omit<SettingsQueryResponse['userSettings'], '__typename'> => {

--- a/ui/src/setting/SettingsPage.tsx
+++ b/ui/src/setting/SettingsPage.tsx
@@ -7,7 +7,7 @@ import {SetSettings, SetSettingsVariables} from '../gql/__generated__/SetSetting
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/NativeSelect/NativeSelect';
-import {DateLocale, Theme, WeekDay} from '../gql/__generated__/globalTypes';
+import {DateLocale, Theme, WeekDay, DatetimeInputStyle} from '../gql/__generated__/globalTypes';
 import {useSnackbar} from 'notistack';
 import {handleError} from '../utils/errors';
 
@@ -114,6 +114,34 @@ export const SettingsPage: React.FC = () => {
                         WeekDay.Friday,
                         WeekDay.Saturday,
                     ].map((type) => (
+                        <option key={type} value={type}>
+                            {type}
+                        </option>
+                    ))}
+                </Select>
+            </FormControl>
+            <FormControl margin={'normal'} fullWidth>
+                <InputLabel>Datetime input style</InputLabel>
+                <Select
+                    fullWidth
+                    value={settings.datetimeInputStyle}
+                    onChange={(e) => {
+                        setSettings({
+                            variables: {
+                                settings: {
+                                    ...settings,
+                                    datetimeInputStyle: e.target.value as DatetimeInputStyle,
+                                },
+                            },
+                        })
+                            .then(() =>
+                                enqueueSnackbar('preferred datetime input style changed', {
+                                    variant: 'success',
+                                })
+                            )
+                            .catch(handleError('set preferred datetime input style', enqueueSnackbar));
+                    }}>
+                    {[DatetimeInputStyle.Fancy, DatetimeInputStyle.Standard].map((type) => (
                         <option key={type} value={type}>
                             {type}
                         </option>

--- a/ui/src/setting/SettingsPage.tsx
+++ b/ui/src/setting/SettingsPage.tsx
@@ -135,11 +135,11 @@ export const SettingsPage: React.FC = () => {
                             },
                         })
                             .then(() =>
-                                enqueueSnackbar('preferred datetime input style changed', {
+                                enqueueSnackbar('datetime input style changed', {
                                     variant: 'success',
                                 })
                             )
-                            .catch(handleError('set preferred datetime input style', enqueueSnackbar));
+                            .catch(handleError('set datetime input style', enqueueSnackbar));
                     }}>
                     {[DatetimeInputStyle.Fancy, DatetimeInputStyle.Native].map((type) => (
                         <option key={type} value={type}>

--- a/ui/src/setting/SettingsPage.tsx
+++ b/ui/src/setting/SettingsPage.tsx
@@ -7,7 +7,7 @@ import {SetSettings, SetSettingsVariables} from '../gql/__generated__/SetSetting
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/NativeSelect/NativeSelect';
-import {DateLocale, Theme, WeekDay, DatetimeInputStyle} from '../gql/__generated__/globalTypes';
+import {DateLocale, Theme, WeekDay, DateTimeInputStyle} from '../gql/__generated__/globalTypes';
 import {useSnackbar} from 'notistack';
 import {handleError} from '../utils/errors';
 
@@ -124,13 +124,13 @@ export const SettingsPage: React.FC = () => {
                 <InputLabel>Datetime input style</InputLabel>
                 <Select
                     fullWidth
-                    value={settings.datetimeInputStyle}
+                    value={settings.dateTimeInputStyle}
                     onChange={(e) => {
                         setSettings({
                             variables: {
                                 settings: {
                                     ...settings,
-                                    datetimeInputStyle: e.target.value as DatetimeInputStyle,
+                                    dateTimeInputStyle: e.target.value as DateTimeInputStyle,
                                 },
                             },
                         })
@@ -141,7 +141,7 @@ export const SettingsPage: React.FC = () => {
                             )
                             .catch(handleError('set datetime input style', enqueueSnackbar));
                     }}>
-                    {[DatetimeInputStyle.Fancy, DatetimeInputStyle.Native].map((type) => (
+                    {[DateTimeInputStyle.Fancy, DateTimeInputStyle.Native].map((type) => (
                         <option key={type} value={type}>
                             {type}
                         </option>

--- a/ui/src/setting/SettingsPage.tsx
+++ b/ui/src/setting/SettingsPage.tsx
@@ -141,7 +141,7 @@ export const SettingsPage: React.FC = () => {
                             )
                             .catch(handleError('set preferred datetime input style', enqueueSnackbar));
                     }}>
-                    {[DatetimeInputStyle.Fancy, DatetimeInputStyle.Standard].map((type) => (
+                    {[DatetimeInputStyle.Fancy, DatetimeInputStyle.Native].map((type) => (
                         <option key={type} value={type}>
                             {type}
                         </option>


### PR DESCRIPTION
The fancy `DateTimeSelector`, while indeed aesthetically pleasing, are a little unweildy and difficult to update manually. This PR adds a setting to replace them with the newer HTML standard `<input type="datetime-local">` pickers, which grant the same functionality with much better accessibility. The default setting is to retain the previous `DateTimeSelector` style.