### PR TITLE
Minor CSS fixes

### DIFF
--- a/ui/src/common/TagChip.tsx
+++ b/ui/src/common/TagChip.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // @ts-ignore
 import bestContrast from 'get-best-contrast-color';
 
-export const TagChip = ({color, label, style = {}}: {label: string; color: string; style?: React.CSSProperties}) => {
+export const TagChip = ({color, label}: {label: string; color: string}) => {
     const textColor = bestContrast(color, ['#fff', '#000']);
     return (
         <Chip
@@ -18,7 +18,6 @@ export const TagChip = ({color, label, style = {}}: {label: string; color: strin
                 height: 'fit-content',
                 whiteSpace: 'normal',
                 wordBreak: 'break-word',
-                ...style,
             }}
             label={label}
         />

--- a/ui/src/common/TagChip.tsx
+++ b/ui/src/common/TagChip.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // @ts-ignore
 import bestContrast from 'get-best-contrast-color';
 
-export const TagChip = ({color, label}: {label: string; color: string}) => {
+export const TagChip = ({color, label, style={}}: {label: string; color: string, style?:React.CSSProperties}) => {
     const textColor = bestContrast(color, ['#fff', '#000']);
     return (
         <Chip
@@ -15,8 +15,10 @@ export const TagChip = ({color, label}: {label: string; color: string}) => {
                 color: textColor,
                 cursor: 'text',
                 minHeight: '32px',
+                height: 'fit-content',
                 whiteSpace: 'normal',
                 wordBreak: 'break-word',
+                ... style
             }}
             label={label}
         />

--- a/ui/src/common/TagChip.tsx
+++ b/ui/src/common/TagChip.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 // @ts-ignore
 import bestContrast from 'get-best-contrast-color';
 
-export const TagChip = ({color, label, style={}}: {label: string; color: string, style?:React.CSSProperties}) => {
+export const TagChip = ({color, label, style = {}}: {label: string; color: string; style?: React.CSSProperties}) => {
     const textColor = bestContrast(color, ['#fff', '#000']);
     return (
         <Chip
@@ -18,7 +18,7 @@ export const TagChip = ({color, label, style={}}: {label: string; color: string,
                 height: 'fit-content',
                 whiteSpace: 'normal',
                 wordBreak: 'break-word',
-                ... style
+                ...style,
             }}
             label={label}
         />

--- a/ui/src/devices/DevicesPage.tsx
+++ b/ui/src/devices/DevicesPage.tsx
@@ -84,13 +84,14 @@ export const DevicesPage = () => {
                                 }
                             }}
                             onSubmit={onClickSubmit}
+                            style={{minWidth: 128}}
                         />
                     ) : (
                         device.name + (isCurrent ? ' (current)' : '')
                     )}
                 </TableCell>
                 <TableCell title={device.createdAt}>{moment(device.createdAt).fromNow()}</TableCell>
-                <TableCell title={device.type}>
+                <TableCell title={device.type} style={{minWidth: 128}}>
                     {isEdited ? (
                         <Select
                             value={editDeviceType}

--- a/ui/src/tag/TagPage.tsx
+++ b/ui/src/tag/TagPage.tsx
@@ -82,16 +82,20 @@ export const TagPage = () => {
                                 }
                             }}
                             onSubmit={onClickSubmit}
+                            style={{ minWidth: 128 }}
                         />
                     ) : (
                         tag.key
                     )}
                 </TableCell>
-                <TableCell>
+                <TableCell style={{minWidth: 128}}>
                     {isEdited ? (
-                        <SliderPicker onChange={(c) => setEditing([editKey, editKeyNew, c.hex])} color={editColor} />
+                        <SliderPicker 
+                        onChange={(c) => setEditing([editKey, editKeyNew, c.hex])} 
+                        color={editColor} 
+                        />
                     ) : (
-                        <TagChip label={tag.color} color={tag.color} />
+                        <TagChip label={tag.color} color={tag.color} style={{wordBreak: "normal"}}/>
                     )}
                 </TableCell>
                 <TableCell align="right">{tag.usages}</TableCell>

--- a/ui/src/tag/TagPage.tsx
+++ b/ui/src/tag/TagPage.tsx
@@ -92,7 +92,7 @@ export const TagPage = () => {
                     {isEdited ? (
                         <SliderPicker onChange={(c) => setEditing([editKey, editKeyNew, c.hex])} color={editColor} />
                     ) : (
-                        <TagChip label={tag.color} color={tag.color} style={{wordBreak: 'normal'}} />
+                        <TagChip label={tag.color} color={tag.color} />
                     )}
                 </TableCell>
                 <TableCell align="right">{tag.usages}</TableCell>

--- a/ui/src/tag/TagPage.tsx
+++ b/ui/src/tag/TagPage.tsx
@@ -82,7 +82,7 @@ export const TagPage = () => {
                                 }
                             }}
                             onSubmit={onClickSubmit}
-                            style={{ minWidth: 128 }}
+                            style={{minWidth: 128}}
                         />
                     ) : (
                         tag.key
@@ -90,12 +90,9 @@ export const TagPage = () => {
                 </TableCell>
                 <TableCell style={{minWidth: 128}}>
                     {isEdited ? (
-                        <SliderPicker 
-                        onChange={(c) => setEditing([editKey, editKeyNew, c.hex])} 
-                        color={editColor} 
-                        />
+                        <SliderPicker onChange={(c) => setEditing([editKey, editKeyNew, c.hex])} color={editColor} />
                     ) : (
-                        <TagChip label={tag.color} color={tag.color} style={{wordBreak: "normal"}}/>
+                        <TagChip label={tag.color} color={tag.color} style={{wordBreak: 'normal'}} />
                     )}
                 </TableCell>
                 <TableCell align="right">{tag.usages}</TableCell>


### PR DESCRIPTION
Some minor CSS changes.

- Tags now wrap properly (again?). 
  From the original [Mobile CSS pr](https://github.com/traggo/server/pull/180) this was added, but I either broke it now and fixed it again or it broke somewhere else. 
  Before and after:
![before](https://github.com/user-attachments/assets/9853be0a-6eb3-44a8-9495-b1cb18ea7be1)
![after](https://github.com/user-attachments/assets/c0680eeb-9344-4d28-bbec-0561fca221b1)

- The tags page tags wrapping has now been fixed:
  Before and after:
![before](https://github.com/user-attachments/assets/83dac864-0519-4299-8563-cabfe197c57b)
![after](https://github.com/user-attachments/assets/6cbdd913-1923-42b8-a3b4-31d4f61e571c)

- Added some min width to the tag page. Helps with editing the name and picking a color on mobile.
  Before and after:
![before](https://github.com/user-attachments/assets/25f25492-546b-4152-8599-52a40b4e0042)
![after](https://github.com/user-attachments/assets/90ea5cae-1570-47c8-a317-cff8c8718363)

- On the devices page the textbox for editing name also has a min width set to help editing as well.


