### PR TITLE
fix: crash on prevously set settings

### DIFF
--- a/setting/usersettings.go
+++ b/setting/usersettings.go
@@ -119,11 +119,11 @@ func toInternalWeekday(weekday gqlmodel.WeekDay) time.Weekday {
 func toExternalDateTimeInputStyle(style string) gqlmodel.DateTimeInputStyle {
 	switch style {
 	case model.DateTimeInputFancy:
-		return model.DateTimeInputFancy
+		return gqlmodel.DateTimeInputStyleFancy
 	case model.DateTimeInputNative:
-		return model.DateTimeInputNative
+		return gqlmodel.DateTimeInputStyleNative
 	default:
-		panic("unknown datetime input style")
+		return gqlmodel.DateTimeInputStyleFancy
 	}
 }
 
@@ -134,6 +134,6 @@ func toInternalDateTimeInputStyle(style gqlmodel.DateTimeInputStyle) string {
 	case gqlmodel.DateTimeInputStyleNative:
 		return model.DateTimeInputNative
 	default:
-		panic("unknown datetime input style")
+		return model.DateTimeInputFancy
 	}
 }

--- a/setting/usersettings_test.go
+++ b/setting/usersettings_test.go
@@ -62,5 +62,7 @@ func TestShouldHandleInvalidInputs(t *testing.T) {
 	toInternalTheme("aoeuaoeu")
 	toExternalDateLocale("aeu")
 	toInternalDateLocale("aoeu")
+	toExternalDateTimeInputStyle("aoeu")
+	toInternalDateTimeInputStyle("aoeu")
 
 }


### PR DESCRIPTION
Traggo should fallback to a default value, if the value in the database is invalid.

See #206 