### PR TITLE
fix: time_span_tags wrong case on edit tag

### DIFF
--- a/tag/update.go
+++ b/tag/update.go
@@ -28,7 +28,8 @@ func (r *ResolverForTag) UpdateTag(ctx context.Context, key string, newKey *stri
 	}
 
 	if newKey != nil && *newKey != key {
-		newValue.Key = strings.ToLower(*newKey)
+		*newKey = strings.ToLower(*newKey)
+		newValue.Key = *newKey
 		timeSpansIdsOfUser := tx.Model(new(model.TimeSpan)).
 			Select("id").
 			Where(&model.TimeSpan{UserID: userID}).

--- a/tag/update_test.go
+++ b/tag/update_test.go
@@ -36,6 +36,26 @@ func TestUpdate_withKey(t *testing.T) {
 	rightTs.AssertHasTag("coolio", "mama", true).AssertHasTag("mega", "mama", false)
 }
 
+func TestUpdate_lowercases(t *testing.T) {
+	db := test.InMemoryDB(t)
+	defer db.Close()
+	user := db.User(5)
+	user.NewTagDefinition("coolio")
+	ts := user.TimeSpan("2009-06-30T18:30:00Z", "2009-06-30T18:40:00Z")
+	ts.Tag("coolio", "mama")
+
+	resolver := ResolverForTag{DB: db.DB}
+	newTagName := "Mega"
+	tag, err := resolver.UpdateTag(fake.User(user.User.ID), "coolio", &newTagName, "#abc")
+	require.NoError(t, err)
+	require.Equal(t, &gqlmodel.TagDefinition{
+		Color: "#abc",
+		Key:   "mega",
+	}, tag)
+	user.AssertHasTagDefinition("coolio", false).AssertHasTagDefinition("mega", true)
+	ts.AssertHasTag("mega", "mama", true).AssertHasTag("coolio", "mama", false)
+}
+
 func TestUpdate_withoutKey(t *testing.T) {
 	db := test.InMemoryDB(t)
 	defer db.Close()


### PR DESCRIPTION
I managed to reproduce the bug in #131. On editing a tag to have uppercase letters, the actual tag saved in `tag_definitions` will be lower case but the update query for `time_span_tags` uses the value as is without lower-casing it.

The fix should prevent that. not sure if/where I should add test cases for it.