### PR TITLE
fix: createTag now checks for spaces in tags

### DIFF
--- a/tag/create.go
+++ b/tag/create.go
@@ -13,6 +13,13 @@ import (
 
 // CreateTag creates a tag.
 func (r *ResolverForTag) CreateTag(ctx context.Context, key string, color string) (*gqlmodel.TagDefinition, error) {
+	if strings.TrimSpace(key) == "" {
+		return nil, fmt.Errorf("tag must not be empty")
+	}
+	if strings.Contains(key, " ") {
+		return nil, fmt.Errorf("tag must not contain spaces")
+	}
+
 	userID := auth.GetUser(ctx).ID
 	definition := &model.TagDefinition{
 		Key:    strings.ToLower(key),

--- a/tag/update.go
+++ b/tag/update.go
@@ -29,6 +29,7 @@ func (r *ResolverForTag) UpdateTag(ctx context.Context, key string, newKey *stri
 
 	if newKey != nil && *newKey != key {
 		if strings.Contains(*newKey, " ") {
+			tx.Rollback()
 			return nil, fmt.Errorf("tag must not contain spaces")
 		}
 		*newKey = strings.ToLower(*newKey)

--- a/tag/update.go
+++ b/tag/update.go
@@ -28,6 +28,9 @@ func (r *ResolverForTag) UpdateTag(ctx context.Context, key string, newKey *stri
 	}
 
 	if newKey != nil && *newKey != key {
+		if strings.Contains(*newKey, " ") {
+			return nil, fmt.Errorf("tag must not contain spaces")
+		}
 		*newKey = strings.ToLower(*newKey)
 		newValue.Key = *newKey
 		timeSpansIdsOfUser := tx.Model(new(model.TimeSpan)).

--- a/tag/update_test.go
+++ b/tag/update_test.go
@@ -56,6 +56,18 @@ func TestUpdate_lowercases(t *testing.T) {
 	ts.AssertHasTag("mega", "mama", true).AssertHasTag("coolio", "mama", false)
 }
 
+func TestUpdate_disallow_space(t *testing.T) {
+	db := test.InMemoryDB(t)
+	defer db.Close()
+	user := db.User(5)
+	user.NewTagDefinition("coolio")
+
+	resolver := ResolverForTag{DB: db.DB}
+	newTagName := "the coolio"
+	_, err := resolver.UpdateTag(fake.User(user.User.ID), "coolio", &newTagName, "#abc")
+	require.EqualError(t, err, "tag must not contain spaces")
+}
+
 func TestUpdate_withoutKey(t *testing.T) {
 	db := test.InMemoryDB(t)
 	defer db.Close()

--- a/ui/src/tag/AddTagDialog.tsx
+++ b/ui/src/tag/AddTagDialog.tsx
@@ -14,6 +14,7 @@ import {AddTag, AddTagVariables} from '../gql/__generated__/AddTag';
 import * as gqlTags from '../gql/tags';
 import {TagSelectorEntry} from './tagSelectorEntry';
 import {useMutation} from '@apollo/react-hooks';
+import Typography from '@material-ui/core/Typography';
 
 interface AddTagDialogProps {
     initialName: string;
@@ -25,16 +26,19 @@ interface AddTagDialogProps {
 export const AddTagDialog: React.FC<AddTagDialogProps> = ({close, open, initialName, onAdded = () => {}}) => {
     const [name, setName] = React.useState(initialName);
     const [color, setColor] = React.useState('#e6b3b3');
+    const [error, setError] = React.useState('');
 
     const [addTag] = useMutation<AddTag, AddTagVariables>(gqlTags.AddTag, {refetchQueries: [{query: gqlTags.Tags}]});
     const submit = (e: React.FormEvent) => {
         e.preventDefault();
-        addTag({variables: {name, color}}).then((result: MutationFetchResult<AddTag> | void) => {
-            close();
-            if (result && result.data && result.data.createTag) {
-                onAdded(result.data.createTag);
-            }
-        });
+        addTag({variables: {name, color}})
+            .then((result: MutationFetchResult<AddTag> | void) => {
+                close();
+                if (result && result.data && result.data.createTag) {
+                    onAdded(result.data.createTag);
+                }
+            })
+            .catch((err) => setError(err.toString()));
     };
 
     return (
@@ -53,6 +57,11 @@ export const AddTagDialog: React.FC<AddTagDialogProps> = ({close, open, initialN
                         value={name}
                         onChange={(e) => setName(e.target.value)}
                     />
+                    {error.length > 0 ? (
+                        <Typography color={'secondary'} variant={'caption'}>
+                            {error}
+                        </Typography>
+                    ) : null}
                     <FormControl fullWidth margin="dense">
                         <InputLabel htmlFor="color-picker" shrink={true}>
                             Color

--- a/ui/src/tag/AddTagDialog.tsx
+++ b/ui/src/tag/AddTagDialog.tsx
@@ -14,7 +14,8 @@ import {AddTag, AddTagVariables} from '../gql/__generated__/AddTag';
 import * as gqlTags from '../gql/tags';
 import {TagSelectorEntry} from './tagSelectorEntry';
 import {useMutation} from '@apollo/react-hooks';
-import Typography from '@material-ui/core/Typography';
+import {useSnackbar} from 'notistack';
+import {handleError} from '../utils/errors';
 
 interface AddTagDialogProps {
     initialName: string;
@@ -26,7 +27,7 @@ interface AddTagDialogProps {
 export const AddTagDialog: React.FC<AddTagDialogProps> = ({close, open, initialName, onAdded = () => {}}) => {
     const [name, setName] = React.useState(initialName);
     const [color, setColor] = React.useState('#e6b3b3');
-    const [error, setError] = React.useState('');
+    const {enqueueSnackbar} = useSnackbar();
 
     const [addTag] = useMutation<AddTag, AddTagVariables>(gqlTags.AddTag, {refetchQueries: [{query: gqlTags.Tags}]});
     const submit = (e: React.FormEvent) => {
@@ -38,7 +39,7 @@ export const AddTagDialog: React.FC<AddTagDialogProps> = ({close, open, initialN
                     onAdded(result.data.createTag);
                 }
             })
-            .catch((err) => setError(err.toString()));
+            .catch(handleError('Add Tag', enqueueSnackbar));
     };
 
     return (
@@ -57,11 +58,6 @@ export const AddTagDialog: React.FC<AddTagDialogProps> = ({close, open, initialN
                         value={name}
                         onChange={(e) => setName(e.target.value)}
                     />
-                    {error.length > 0 ? (
-                        <Typography color={'secondary'} variant={'caption'}>
-                            {error}
-                        </Typography>
-                    ) : null}
                     <FormControl fullWidth margin="dense">
                         <InputLabel htmlFor="color-picker" shrink={true}>
                             Color

--- a/ui/src/tag/TagPage.tsx
+++ b/ui/src/tag/TagPage.tsx
@@ -66,7 +66,8 @@ export const TagPage = () => {
                     newKey: editKeyNew,
                     color: editColor,
                 },
-            }).then(() => enqueueSnackbar('tag edited', {variant: 'success'}))
+            })
+                .then(() => enqueueSnackbar('tag edited', {variant: 'success'}))
                 .catch(handleError('Edit Tag', enqueueSnackbar));
         };
         const isEdited = editKey === tag.key;

--- a/ui/src/tag/TagPage.tsx
+++ b/ui/src/tag/TagPage.tsx
@@ -66,7 +66,8 @@ export const TagPage = () => {
                     newKey: editKeyNew,
                     color: editColor,
                 },
-            }).then(() => enqueueSnackbar('tag edited', {variant: 'success'}));
+            }).then(() => enqueueSnackbar('tag edited', {variant: 'success'}))
+                .catch(handleError('Edit Tag', enqueueSnackbar));
         };
         const isEdited = editKey === tag.key;
         return (


### PR DESCRIPTION
You mentioned in #72 that create tag page should not allow creating tags with spaces in them.

While fixing that I also noticed that the dialogue lets you actually make an empty tag!

And that the ui does not in any way react to receiving an error (e.g. duplicate tag).

So this PR tries to fix all of the above. CreateTag mutation now checks for empty tag and tags with spaces, and the ui shows the error similar to how other ui elements (e.g. `RelativeDateTimeSelector`) do by adding a red text under the input box.