### PR TITLE
Add support for storing filters in dashboard entries

### DIFF
--- a/dashboard/convert/dashboardtag.go
+++ b/dashboard/convert/dashboardtag.go
@@ -1,0 +1,58 @@
+package convert
+
+import (
+	"github.com/traggo/server/generated/gqlmodel"
+	"github.com/traggo/server/model"
+)
+
+func excludedTagsToExternal(tags []model.DashboardExcludedTag) []*gqlmodel.TimeSpanTag {
+	result := []*gqlmodel.TimeSpanTag{}
+	for _, tag := range tags {
+		result = append(result, &gqlmodel.TimeSpanTag{
+			Key:   tag.Key,
+			Value: tag.StringValue,
+		})
+	}
+	return result
+}
+
+func ExcludedTagsToInternal(gqls []*gqlmodel.InputTimeSpanTag) []model.DashboardExcludedTag {
+	result := make([]model.DashboardExcludedTag, 0)
+	for _, tag := range gqls {
+		result = append(result, excludedTagToInternal(*tag))
+	}
+	return result
+}
+
+func excludedTagToInternal(gqls gqlmodel.InputTimeSpanTag) model.DashboardExcludedTag {
+	return model.DashboardExcludedTag{
+		Key:         gqls.Key,
+		StringValue: gqls.Value,
+	}
+}
+
+func includedTagsToExternal(tags []model.DashboardIncludedTag) []*gqlmodel.TimeSpanTag {
+	result := []*gqlmodel.TimeSpanTag{}
+	for _, tag := range tags {
+		result = append(result, &gqlmodel.TimeSpanTag{
+			Key:   tag.Key,
+			Value: tag.StringValue,
+		})
+	}
+	return result
+}
+
+func IncludedTagsToInternal(gqls []*gqlmodel.InputTimeSpanTag) []model.DashboardIncludedTag {
+	result := make([]model.DashboardIncludedTag, 0)
+	for _, tag := range gqls {
+		result = append(result, includedTagToInternal(*tag))
+	}
+	return result
+}
+
+func includedTagToInternal(gqls gqlmodel.InputTimeSpanTag) model.DashboardIncludedTag {
+	return model.DashboardIncludedTag{
+		Key:         gqls.Key,
+		StringValue: gqls.Value,
+	}
+}

--- a/dashboard/convert/entry.go
+++ b/dashboard/convert/entry.go
@@ -38,9 +38,11 @@ func ToExternalEntry(entry model.DashboardEntry) (*gqlmodel.DashboardEntry, erro
 		To:   entry.RangeTo,
 	}
 	stats := &gqlmodel.StatsSelection{
-		Interval: ExternalInterval(entry.Interval),
-		Tags:     strings.Split(entry.Keys, ","),
-		Range:    dateRange,
+		Interval:    ExternalInterval(entry.Interval),
+		Tags:        strings.Split(entry.Keys, ","),
+		Range:       dateRange,
+		ExcludeTags: excludedTagsToExternal(entry.ExcludedTags),
+		IncludeTags: includedTagsToExternal(entry.IncludedTags),
 	}
 	if entry.RangeID != model.NoRangeIDDefined {
 		stats.RangeID = &entry.RangeID

--- a/dashboard/entry/tagcheck.go
+++ b/dashboard/entry/tagcheck.go
@@ -1,0 +1,43 @@
+package entry
+
+import (
+	"fmt"
+
+	"github.com/jinzhu/gorm"
+	"github.com/traggo/server/generated/gqlmodel"
+	"github.com/traggo/server/model"
+)
+
+func tagsDuplicates(src []*gqlmodel.InputTimeSpanTag, dst []*gqlmodel.InputTimeSpanTag) *gqlmodel.InputTimeSpanTag {
+	existingTags := make(map[string]struct{})
+	for _, tag := range src {
+		existingTags[tag.Key+":"+tag.Value] = struct{}{}
+	}
+
+	for _, tag := range dst {
+		if _, ok := existingTags[tag.Key+":"+tag.Value]; ok {
+			return tag
+		}
+
+		existingTags[tag.Key] = struct{}{}
+	}
+
+	return nil
+}
+
+func tagsExist(db *gorm.DB, userID int, tags []*gqlmodel.InputTimeSpanTag) error {
+	existingTags := make(map[string]struct{})
+
+	for _, tag := range tags {
+		if _, ok := existingTags[tag.Key]; ok {
+			return fmt.Errorf("tag '%s' is present multiple times", tag.Key)
+		}
+
+		if db.Where("key = ?", tag.Key).Where("user_id = ?", userID).Find(new(model.TagDefinition)).RecordNotFound() {
+			return fmt.Errorf("tag '%s' does not exist", tag.Key)
+		}
+
+		existingTags[tag.Key] = struct{}{}
+	}
+	return nil
+}

--- a/dashboard/get.go
+++ b/dashboard/get.go
@@ -15,7 +15,14 @@ func (r *ResolverForDashboard) Dashboards(ctx context.Context) ([]*gqlmodel.Dash
 	userID := auth.GetUser(ctx).ID
 
 	dashboards := []model.Dashboard{}
-	find := r.DB.Preload("Entries").Preload("Ranges").Where(&model.Dashboard{UserID: userID}).Find(&dashboards)
+
+	q := r.DB
+	q = q.Preload("Entries")
+	q = q.Preload("Entries.ExcludedTags")
+	q = q.Preload("Entries.IncludedTags")
+	q = q.Preload("Ranges")
+
+	find := q.Where(&model.Dashboard{UserID: userID}).Find(&dashboards)
 
 	if find.Error != nil {
 		return nil, find.Error

--- a/model/all.go
+++ b/model/all.go
@@ -11,6 +11,8 @@ func All() []interface{} {
 		new(UserSetting),
 		new(Dashboard),
 		new(DashboardEntry),
+		new(DashboardExcludedTag),
+		new(DashboardIncludedTag),
 		new(DashboardRange),
 	}
 }

--- a/model/dashboard.go
+++ b/model/dashboard.go
@@ -26,19 +26,35 @@ type Dashboard struct {
 
 // DashboardEntry an entry which represents a diagram in a dashboard.
 type DashboardEntry struct {
-	ID          int `gorm:"primary_key;unique_index;AUTO_INCREMENT"`
-	DashboardID int `gorm:"type:int REFERENCES dashboards(id) ON DELETE CASCADE"`
-	Title       string
-	Total       bool `gorm:"default:false"`
-	Type        DashboardType
-	Keys        string
-	Interval    Interval
-	RangeID     int
-	RangeFrom   string
-	RangeTo     string
+	ID           int `gorm:"primary_key;unique_index;AUTO_INCREMENT"`
+	DashboardID  int `gorm:"type:int REFERENCES dashboards(id) ON DELETE CASCADE"`
+	Title        string
+	Total        bool `gorm:"default:false"`
+	Type         DashboardType
+	Keys         string
+	Interval     Interval
+	RangeID      int
+	RangeFrom    string
+	RangeTo      string
+	ExcludedTags []DashboardExcludedTag
+	IncludedTags []DashboardIncludedTag
 
 	MobilePosition  string
 	DesktopPosition string
+}
+
+// DashboardExcludedTag a tag for filtering timespans
+type DashboardExcludedTag struct {
+	DashboardEntryID int `gorm:"type:int REFERENCES dashboard_entries(id) ON DELETE CASCADE"`
+	Key              string
+	StringValue      string
+}
+
+// DashboardIncludedTag a tag for filtering timespans
+type DashboardIncludedTag struct {
+	DashboardEntryID int `gorm:"type:int REFERENCES dashboard_entries(id) ON DELETE CASCADE"`
+	Key              string
+	StringValue      string
 }
 
 // DashboardType the dashboard type

--- a/ui/src/dashboard/Entry/AddPopup.tsx
+++ b/ui/src/dashboard/Entry/AddPopup.tsx
@@ -10,6 +10,8 @@ import * as gqlDashboard from '../../gql/dashboard';
 import {Fade} from '../../common/Fade';
 import {DashboardEntryForm, isValidDashboardEntry} from './DashboardEntryForm';
 import {AddDashboardEntry, AddDashboardEntryVariables} from '../../gql/__generated__/AddDashboardEntry';
+import {handleError} from '../../utils/errors';
+import {useSnackbar} from 'notistack';
 
 interface EditPopupProps {
     dashboardId: number;
@@ -38,6 +40,9 @@ export const AddPopup: React.FC<EditPopupProps> = ({
         refetchQueries: [{query: gqlDashboard.Dashboards}],
     });
     const valid = isValidDashboardEntry(entry);
+
+    const {enqueueSnackbar} = useSnackbar();
+
     return (
         <Popper
             key="popup"
@@ -89,6 +94,8 @@ export const AddPopup: React.FC<EditPopupProps> = ({
                                                       }
                                                     : null,
                                                 rangeId: entry.statsSelection.rangeId,
+                                                excludeTags: entry.statsSelection.excludeTags,
+                                                includeTags: entry.statsSelection.includeTags,
                                             },
                                             pos: {
                                                 desktop: {
@@ -99,7 +106,9 @@ export const AddPopup: React.FC<EditPopupProps> = ({
                                                 },
                                             },
                                         },
-                                    }).then(finish);
+                                    })
+                                        .then(finish)
+                                        .catch(handleError('Add Dashboard Entry', enqueueSnackbar));
                                 }}>
                                 Add
                             </Button>

--- a/ui/src/dashboard/Entry/DashboardEntry.tsx
+++ b/ui/src/dashboard/Entry/DashboardEntry.tsx
@@ -52,6 +52,8 @@ const SpecificDashboardEntry: React.FC<{entry: Dashboards_dashboards_items; rang
                 range,
                 interval,
                 tags: entry.statsSelection.tags,
+                excludeTags: entry.statsSelection.excludeTags,
+                includeTags: entry.statsSelection.includeTags,
             },
         },
     });

--- a/ui/src/dashboard/Entry/DashboardEntryForm.tsx
+++ b/ui/src/dashboard/Entry/DashboardEntryForm.tsx
@@ -5,6 +5,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/NativeSelect/NativeSelect';
 import {EntryType, StatsInterval} from '../../gql/__generated__/globalTypes';
 import {TagKeySelector} from '../../tag/TagKeySelector';
+import {TagFilterSelector} from '../../tag/TagFilterSelector';
 import {Dashboards_dashboards_items, Dashboards_dashboards_items_statsSelection_range} from '../../gql/__generated__/Dashboards';
 import {RelativeDateTimeSelector} from '../../common/RelativeDateTimeSelector';
 import {parseRelativeTime} from '../../utils/time';
@@ -30,6 +31,27 @@ export const isValidDashboardEntry = (item: Dashboards_dashboards_items): boolea
 };
 export const DashboardEntryForm: React.FC<EditPopupProps> = ({entry, onChange: setEntry, disabled = false, ranges}) => {
     const [staticRange, setStaticRange] = React.useState(!entry.statsSelection.rangeId);
+
+    const [excludeTags, setExcludeTags] = React.useState(
+        (entry.statsSelection.excludeTags || []).map((tag) => ({
+            tag: {
+                key: tag.key,
+                color: '',
+                __typename: 'TagDefinition' as 'TagDefinition',
+            },
+            value: tag.value,
+        }))
+    );
+    const [includeTags, setIncludeTags] = React.useState(
+        (entry.statsSelection.includeTags || []).map((tag) => ({
+            tag: {
+                key: tag.key,
+                color: '',
+                __typename: 'TagDefinition' as 'TagDefinition',
+            },
+            value: tag.value,
+        }))
+    );
 
     const range: Dashboards_dashboards_items_statsSelection_range = entry.statsSelection.range
         ? entry.statsSelection.range
@@ -186,6 +208,32 @@ export const DashboardEntryForm: React.FC<EditPopupProps> = ({entry, onChange: s
                 disabled={disabled}
                 onChange={(tags) => {
                     entry.statsSelection.tags = tags;
+                    setEntry(entry);
+                }}
+            />
+            <TagFilterSelector
+                type="Exclude"
+                value={excludeTags}
+                onChange={(tags) => {
+                    setExcludeTags(tags);
+                    entry.statsSelection.excludeTags = tags.map((tag) => ({
+                        key: tag.tag.key,
+                        value: tag.value,
+                        __typename: 'TimeSpanTag',
+                    }));
+                    setEntry(entry);
+                }}
+            />
+            <TagFilterSelector
+                type="Include"
+                value={includeTags}
+                onChange={(tags) => {
+                    setIncludeTags(tags);
+                    entry.statsSelection.includeTags = tags.map((tag) => ({
+                        key: tag.tag.key,
+                        value: tag.value,
+                        __typename: 'TimeSpanTag',
+                    }));
                     setEntry(entry);
                 }}
             />

--- a/ui/src/dashboard/Entry/EditPopup.tsx
+++ b/ui/src/dashboard/Entry/EditPopup.tsx
@@ -10,6 +10,8 @@ import * as gqlDashboard from '../../gql/dashboard';
 import {UpdateDashboardEntry, UpdateDashboardEntryVariables} from '../../gql/__generated__/UpdateDashboardEntry';
 import {Fade} from '../../common/Fade';
 import {DashboardEntryForm, isValidDashboardEntry} from './DashboardEntryForm';
+import {handleError} from '../../utils/errors';
+import {useSnackbar} from 'notistack';
 
 interface EditPopupProps {
     entry: Dashboards_dashboards_items;
@@ -24,6 +26,9 @@ export const EditPopup: React.FC<EditPopupProps> = ({entry, anchorEl, onChange: 
         refetchQueries: [{query: gqlDashboard.Dashboards}],
     });
     const valid = isValidDashboardEntry(entry);
+
+    const {enqueueSnackbar} = useSnackbar();
+
     return (
         <Popper
             key="popup"
@@ -75,9 +80,13 @@ export const EditPopup: React.FC<EditPopupProps> = ({entry, anchorEl, onChange: 
                                                       }
                                                     : null,
                                                 rangeId: entry.statsSelection.rangeId,
+                                                excludeTags: entry.statsSelection.excludeTags,
+                                                includeTags: entry.statsSelection.includeTags,
                                             },
                                         },
-                                    }).then(() => setEdit(null));
+                                    })
+                                        .then(() => setEdit(null))
+                                        .catch(handleError('Edit Dashboard Entry', enqueueSnackbar));
                                 }}>
                                 Save
                             </Button>

--- a/ui/src/tag/TagFilterSelector.tsx
+++ b/ui/src/tag/TagFilterSelector.tsx
@@ -1,0 +1,152 @@
+import React from 'react';
+import Downshift from 'downshift';
+import {makeStyles, Theme} from '@material-ui/core/styles';
+import TextField from '@material-ui/core/TextField';
+import Paper from '@material-ui/core/Paper';
+import MenuItem from '@material-ui/core/MenuItem';
+import Chip from '@material-ui/core/Chip';
+import {useQuery} from '@apollo/react-hooks';
+import {Tags} from '../gql/__generated__/Tags';
+import {TagSelectorEntry, label} from './tagSelectorEntry';
+import * as gqlTags from '../gql/tags';
+import {useSuggest} from './suggest';
+
+const useStyles = makeStyles((theme: Theme) => ({
+    root: {
+        flexGrow: 1,
+        height: 250,
+    },
+    container: {
+        flexGrow: 1,
+        position: 'relative',
+    },
+    paper: {
+        position: 'absolute',
+        zIndex: 1,
+        marginTop: theme.spacing(1),
+        left: 0,
+        right: 0,
+    },
+    chip: {
+        margin: theme.spacing(0.5, 0.25),
+    },
+    inputRoot: {
+        flexWrap: 'wrap',
+    },
+    inputInput: {
+        width: 'auto',
+        flexGrow: 1,
+    },
+}));
+
+interface TagFilterSelectorProps {
+    value: TagSelectorEntry[];
+    type: string;
+    onChange: (entries: TagSelectorEntry[]) => void;
+    disabled?: boolean;
+}
+
+export const TagFilterSelector: React.FC<TagFilterSelectorProps> = ({value: selectedItem, type, onChange, disabled = false}) => {
+    const classes = useStyles();
+    const [inputValue, setInputValue] = React.useState('');
+
+    const tagsResult = useQuery<Tags>(gqlTags.Tags);
+    const suggestions = useSuggest(tagsResult, inputValue, [])
+        .filter((t) => !t.tag.create && !t.tag.alreadyUsed)
+        .reverse();
+
+    if (tagsResult.error || tagsResult.loading || !tagsResult.data || !tagsResult.data.tags) {
+        return null;
+    }
+
+    function handleKeyDown(event: React.KeyboardEvent) {
+        if (selectedItem.length && !inputValue.length && event.key === 'Backspace') {
+            onChange(selectedItem.slice(0, selectedItem.length - 1));
+        }
+    }
+
+    function handleInputChange(event: React.ChangeEvent<{value: string}>) {
+        setInputValue(event.target.value);
+    }
+
+    function handleChange(item: TagSelectorEntry) {
+        if (!item.value) {
+            setInputValue(item.tag.key + ':');
+            return;
+        }
+        let newSelectedItem = [...selectedItem];
+        if (newSelectedItem.indexOf(item) === -1) {
+            newSelectedItem = [...newSelectedItem, item];
+        }
+        setInputValue('');
+        onChange(newSelectedItem);
+    }
+
+    const handleDelete = (item: TagSelectorEntry) => () => {
+        const newSelectedItem = [...selectedItem];
+        newSelectedItem.splice(newSelectedItem.indexOf(item), 1);
+        onChange(newSelectedItem);
+    };
+
+    return (
+        <Downshift
+            id="downshift-multiple"
+            inputValue={inputValue}
+            onChange={handleChange}
+            itemToString={(item) => (item ? label(item) : '')}
+            defaultIsOpen={false}>
+            {({getInputProps, getItemProps, getLabelProps, isOpen, highlightedIndex}) => {
+                const {onBlur, onChange: downshiftOnChange, onFocus, ...inputProps} = getInputProps({
+                    onKeyDown: handleKeyDown,
+                    placeholder: `Select ${type} Tags`,
+                });
+                return (
+                    <div className={classes.container}>
+                        <TextField
+                            InputLabelProps={getLabelProps()}
+                            required={true}
+                            disabled={disabled}
+                            InputProps={{
+                                classes: {
+                                    root: classes.inputRoot,
+                                    input: classes.inputInput,
+                                },
+                                startAdornment: selectedItem.map((item) => (
+                                    <Chip
+                                        key={label(item)}
+                                        tabIndex={-1}
+                                        label={label(item)}
+                                        className={classes.chip}
+                                        onDelete={disabled ? undefined : handleDelete(item)}
+                                    />
+                                )),
+                                onBlur,
+                                onChange: (event) => {
+                                    handleInputChange(event);
+                                    downshiftOnChange!(event as React.ChangeEvent<HTMLInputElement>);
+                                },
+                                onFocus,
+                            }}
+                            label={`${type} Tags`}
+                            fullWidth
+                            inputProps={inputProps}
+                        />
+                        {isOpen ? (
+                            <Paper className={classes.paper} square>
+                                {suggestions.map((suggestion, index) => (
+                                    <MenuItem
+                                        {...getItemProps({item: suggestion})}
+                                        key={label(suggestion)}
+                                        selected={highlightedIndex === index}
+                                        component="div">
+                                        {label(suggestion)}
+                                    </MenuItem>
+                                ))}
+                            </Paper>
+                        ) : null}
+                    </div>
+                );
+            }}
+        </Downshift>
+    );
+};


### PR DESCRIPTION
closes #102 
This PR adds support for storing filters and changing them in the dashboard entry form.
It adds 2 new tables for storing filters and a component for choosing them.

I wanted to make it so that the Downshift opens again if the tag is not fully finished, but I could not find a way to do this.
I am open to any suggestions regarding my code, and I haven't written any tests yet.. That's why it's a draft PR.