### PR TITLE
set cache header on all static assets

### DIFF
--- a/ui/serve.go
+++ b/ui/serve.go
@@ -22,7 +22,12 @@ func Register(r *mux.Router) {
 	r.Handle("/manifest.json", serveFile("manifest.json", "application/json"))
 	r.Handle("/service-worker.js", serveFile("service-worker.js", "text/javascript"))
 	r.Handle("/asset-manifest.json", serveFile("asset-manifest.json", "application/json"))
-	r.Handle("/static/{type}/{resource}", http.FileServer(http.FS(buildDir)))
+
+	fileServer := http.FileServer(http.FS(buildDir))
+	r.Handle("/static/{type}/{resource}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		fileServer.ServeHTTP(w, r)
+	}))
 
 	r.Handle("/favicon.ico", serveFile("favicon.ico", "image/x-icon"))
 	for _, size := range []string{"16x16", "32x32", "192x192", "256x256"} {


### PR DESCRIPTION
This sets a `public, max-age=31536000, immutable` response for cache control on all static resource. All the files in the static directory contain a hash in their filename, so cache busting will apply if they ever change.

Before:
<img width="707" height="871" alt="image" src="https://github.com/user-attachments/assets/dd3410ef-38ee-43f2-acb9-279cdc2e5e28" />

After:
<img width="709" height="955" alt="image" src="https://github.com/user-attachments/assets/ef63a407-76cc-440a-8cd8-e47dfad15914" />
