### PR TITLE
Display a continue button when stopped

### DIFF
--- a/ui/src/timespan/TimeSpan.tsx
+++ b/ui/src/timespan/TimeSpan.tsx
@@ -296,6 +296,8 @@ export const TimeSpan: React.FC<TimeSpanProps> = React.memo(
                                 title="The amount of time between from and to">
                                 {to ? <RelativeTime from={from} to={to} /> : <RelativeToNow from={from} />}
                             </Typography>
+                        </div>
+                        <div style={{alignItems: 'center', display: 'flex'}}>
                             {to ? (
                                 <Button
                                     onClick={() => {


### PR DESCRIPTION
Relates to #216 

This change adds a continue button to the timespan UI, which is only visible when items are not active.

<img width="1133" height="389" alt="image" src="https://github.com/user-attachments/assets/c093f2c8-4574-4086-9c38-80d0df55e9e0" />

<img width="438" height="885" alt="image" src="https://github.com/user-attachments/assets/49b96ffc-185e-44ea-a3af-a17319551539" />
