### PR TITLE
Link to traggo opens in new tab

### DIFF
--- a/ui/src/common/Page.tsx
+++ b/ui/src/common/Page.tsx
@@ -119,12 +119,12 @@ export const Page: React.FC = ({children}) => {
     const drawer = (
         <div>
             <div className={classes.toolbar}>
-                <HrefLink href="https://github.com/traggo" underline="none">
+                <HrefLink href="https://github.com/traggo" underline="none" target="_blank">
                     <Typography variant="h5" align="center" color="textPrimary">
                         traggo
                     </Typography>
                 </HrefLink>
-                <HrefLink href="https://github.com/traggo/server/releases" underline="none">
+                <HrefLink href="https://github.com/traggo/server/releases" underline="none" target="_blank">
                     <Typography variant="subtitle2" align="center" color="textPrimary">
                         {version.name}@{version.commit.slice(0, 8)}
                     </Typography>


### PR DESCRIPTION
hello!

fixes #236 

I just used `target="_blank"` to make it open in a new tab. It will automatically redirect you to the open page without deleting the traggo tab. 