### PR TITLE
feat: add optional embedded external view to dashboards

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,255 @@
+# Deploying Traggo with Grafana (embedded dashboards)
+
+This guide describes how to run the embedded-view fork of Traggo together with
+Grafana, using Podman pods (or Docker as an alternative). The whole setup is a
+single Podman pod with two containers and one shared volume:
+
+```
+┌────────────────────── pod traggo-pod ──────────────────────┐
+│  traggo  (UI+API, sqlite)        grafana  (dashboards)     │
+│  :3030 ──► host 8080             :3000 ──► host 3000       │
+│                                                             │
+│  shared volume "traggo-data" mounted at /data in both       │
+│  traggo writes /data/traggo.db, grafana opens the same      │
+│  file (needs write access, see "File permissions")          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 1. Build the server image
+
+The embedded view is a frontend-only change, so the image has to be built from
+this repository (the upstream image does not contain it):
+
+```bash
+# build the UI (on Node 17+ this needs the legacy OpenSSL provider for webpack 4)
+(cd ui && NODE_OPTIONS=--openssl-legacy-provider CI=true yarn build)
+
+# build the server binary (distroless base images ship glibc, so the default
+# dynamic linking is fine; the Makefile's static build needs glibc-static)
+CGO_ENABLED=1 go build -o build/traggo-server .
+```
+
+Then create an image with a minimal distroless Containerfile:
+
+```dockerfile
+FROM gcr.io/distroless/base-debian12
+WORKDIR /opt/traggo
+COPY traggo-server /opt/traggo/traggo
+EXPOSE 3030
+ENTRYPOINT ["./traggo"]
+```
+
+```bash
+podman build -t localhost/traggo/server:embed .
+```
+
+## 2. Create the pod and the volume
+
+```bash
+podman pod create --name traggo-pod -p 8080:3030 -p 3000:3000
+podman volume create traggo-data
+```
+
+Ports are published at pod level; the containers reach each other over
+`localhost` inside the pod.
+
+## 3. Run Traggo
+
+```bash
+podman run -d --pod traggo-pod --name traggo \
+  -e TRAGGO_DATABASE_DIALECT=sqlite3 \
+  -e 'TRAGGO_DATABASE_CONNECTION=/data/traggo.db?_busy_timeout=20000' \
+  -v traggo-data:/data:z \
+  localhost/traggo/server:embed
+```
+
+The `_busy_timeout=20000` connection parameter prevents SQLite `database is
+locked` errors when Grafana reads the same file.
+
+## 4. Run Grafana
+
+```bash
+podman run -d --pod traggo-pod --name grafana \
+  -e GF_INSTALL_PLUGINS=frser-sqlite-datasource \
+  -v traggo-data:/data:z \
+  -v grafana-data:/var/lib/grafana:z \
+  -v /path/to/grafana.ini:/etc/grafana/grafana.ini:z \
+  -v /path/to/provisioning:/etc/grafana/provisioning:z \
+  docker.io/grafana/grafana:11.5.2
+```
+
+`GF_INSTALL_PLUGINS` installs the SQLite datasource plugin on first start.
+`traggo-data:/data` gives Grafana access to the Traggo database file, which is
+used as the datasource (see below). `grafana-data` persists Grafana's own data,
+`grafana.ini` and `provisioning` hold the configuration from this folder.
+
+### File permissions (important)
+
+The Grafana 11.x image runs as the non-root user `grafana` (uid 472), and the
+frser plugin opens the SQLite file read-write. If it cannot open it for writing
+it fails SILENTLY: the datasource health check reports OK and queries return
+empty frames — the dashboard renders but shows no data.
+
+The volume and database file must therefore be writable by uid 472. In rootless
+podman the container group id 0 maps to your host user's group, so group write
+permission is enough:
+
+```bash
+VOLUME_DIR="$HOME/.local/share/containers/storage/volumes/traggo-data/_data"
+chmod 2775 "$VOLUME_DIR"          # group-writable, inherits group for new files
+chmod 664  "$VOLUME_DIR/traggo.db"
+```
+
+Run the traggo container first so `traggo.db` exists (traggo creates it on
+first start), then apply the chmods before starting grafana. With rootful
+podman or Docker the same commands work unchanged.
+
+### SELinux (Fedora/RHEL)
+
+Bind mounts and volumes need `:z` so the containers can access them. Do not use
+`:Z` for volumes shared between the two containers — `:Z` relabels the volume
+private to one container and would break the sharing.
+
+## 5. Configure Grafana
+
+`grafana.ini`:
+
+```ini
+[security]
+allow_embedding = true
+
+[auth.anonymous]
+enabled = true
+org_name = Main Org.
+org_role = Editor
+```
+
+`allow_embedding` is required for the dashboard to render inside the iframe on
+the Traggo page. The anonymous user needs Editor to read the dashboards; keep
+them in a folder that is visible to anonymous (see below).
+
+Datasource provisioning (`provisioning/datasources/datasources.yml`):
+
+```yaml
+apiVersion: 1
+
+datasources:
+  - name: Traggo SQLite
+    type: frser-sqlite-datasource
+    access: proxy
+    uid: traggo-sqlite
+    orgId: 1
+    isDefault: true
+    editable: true
+    jsonData:
+      path: /data/traggo.db
+```
+
+Dashboard provisioning (`provisioning/dashboards/dashboards.yml`):
+
+```yaml
+apiVersion: 1
+
+providers:
+  - name: traggo
+    orgId: 1
+    folder: Traggo
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/traggo
+```
+
+Create the `Traggo` folder in the Grafana UI and import your dashboard
+(or export it from an existing instance and place the JSON in that path).
+Dashboards reference the datasource by uid `traggo-sqlite` and the folder named
+`Traggo` — adjust both if your instance differs.
+
+### Provisioning vs. UI edits
+
+File provisioning in Grafana 11.x always overwrites the dashboard (the
+`overwrite: false` option is ignored). To keep layout edits made in the UI,
+import the dashboard once and then move the JSON out of the provisioning folder;
+`disableDeletion: true` keeps the dashboard alive when the file disappears.
+
+## 6. Lifecycle
+
+```bash
+podman pod start traggo-pod    # or: podman start traggo grafana
+podman pod stop traggo-pod
+podman ps --pod
+podman logs -f traggo          # or: grafana
+```
+
+Auto-start at boot with systemd (user units):
+
+```bash
+mkdir -p ~/.config/systemd/user
+podman generate systemd --new --name traggo-pod -f ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now traggo-pod-pod.service
+loginctl enable-linger $USER   # keep user services running without login
+```
+
+## Docker alternative
+
+The same setup with Docker: create a shared network, mount the volume, and give
+Grafana the same file path. Equivalent `docker-compose.yml` (do not mount
+`traggo-data` read-only — the plugin needs to open the file for writing; apply
+the same chmod/chown from the permissions section above, rootful Docker
+included):
+
+```yaml
+services:
+  traggo:
+    image: localhost/traggo/server:embed
+    ports: ["8080:3030"]
+    environment:
+      TRAGGO_DATABASE_DIALECT: sqlite3
+      TRAGGO_DATABASE_CONNECTION: /data/traggo.db?_busy_timeout=20000
+    volumes: ["traggo-data:/data"]
+  grafana:
+    image: docker.io/grafana/grafana:11.5.2
+    ports: ["3000:3000"]
+    environment:
+      GF_INSTALL_PLUGINS: frser-sqlite-datasource
+    volumes:
+      - traggo-data:/data
+      - grafana-data:/var/lib/grafana
+      - ./grafana.ini:/etc/grafana/grafana.ini
+      - ./provisioning:/etc/grafana/provisioning
+volumes:
+  traggo-data:
+  grafana-data:
+```
+
+## Embedding other tools
+
+The embedded view is tool-agnostic: Traggo renders the URL you configure per
+dashboard as-is — no transformation is applied. Paste the plain dashboard URL
+(e.g. `http://localhost:3000/d/traggo-study-overview/traggo-overview?orgId=1&from=now-30d&to=now&timezone=browser&var-tag=$__all&refresh=1m`).
+Only if you want to hide the tool's own chrome inside the iframe, append its
+kiosk parameter yourself (Grafana `?kiosk`, Superset `?standalone=true`,
+Metabase ...).
+
+## SQL gotchas for custom panels
+
+- frser-sqlite-datasource types each column from the FIRST row's value. Pad
+  with `0.0` (`ELSE 0.0 END`, `COALESCE(x, 0.0)`) instead of `0`, otherwise
+  fractional hours are truncated to integers.
+- Exclude running entries with `ts.end_utc IS NOT NULL`.
+
+## Troubleshooting
+
+- **Grafana exits at startup with `attempt to write a readonly database`** —
+  `/var/lib/grafana` is not writable by uid 472, typically after restoring a
+  backup. Fix: `podman unshare chown -R 472:472 <grafana-data-dir>` (rootful
+  podman/Docker: `chown -R 472:472 <dir>`), then restart grafana.
+- **Dashboard renders but shows "No data", datasource health check is OK** —
+  the SQLite file cannot be opened for writing (see "File permissions"
+  above). The frser plugin swallows this error and returns empty results.
+- **`database is locked` errors on the Traggo side** — the
+  `_busy_timeout=20000` parameter is missing from
+  `TRAGGO_DATABASE_CONNECTION`.

--- a/ui/src/dashboard/DashboardPage.tsx
+++ b/ui/src/dashboard/DashboardPage.tsx
@@ -13,7 +13,7 @@ import {EditGlass} from './Entry/EditGlass';
 import {Fade} from '../common/Fade';
 import {CenteredSpinner} from '../common/CenteredSpinner';
 import {AddPopup} from './Entry/AddPopup';
-import {Paper} from '@material-ui/core';
+import {Paper, Typography} from '@material-ui/core';
 import {Center} from '../common/Center';
 import {RemoveDashboardEntry, RemoveDashboardEntryVariables} from '../gql/__generated__/RemoveDashboardEntry';
 import {RouteChildrenProps} from 'react-router';
@@ -21,6 +21,7 @@ import {useSnackbar} from 'notistack';
 import {DateRanges} from './DateRanges';
 import {Range} from '../utils/range';
 import {useStateAndDelegateWithDelayOnChange} from '../utils/hooks';
+import {ExternalUrlDialog, getExternalUrl, kioskUrl, setExternalUrl} from './ExternalView';
 
 enum ViewType {
     Mobile = 'mobile',
@@ -90,6 +91,10 @@ export const DashboardPage: React.FC<RouterProps> = ({match, history}) => {
     const [ranges, setRanges] = useStateAndDelegateWithDelayOnChange<Record<number, Range>>({}, setDiagramRanges, 2000);
     const [addEntry, setAddEntry] = React.useState<null | Dashboards_dashboards_items>(null);
     const [[editElement, editEntry], setEdit] = React.useState<[null] | [HTMLElement, Dashboards_dashboards_items]>([null]);
+    const [externalDialogOpen, setExternalDialogOpen] = React.useState(false);
+    const [externalUrl, setExternalUrlState] = React.useState<string>(() =>
+        match && match.params.id ? getExternalUrl(parseInt(match.params.id, 10)) : ''
+    );
     const {loading, data, error} = useQuery<Dashboards>(gqlDashboard.Dashboards);
     const [updatePos] = useMutation<UpdatePos, UpdatePosVariables>(gqlDashboard.UpdatePos, {
         refetchQueries: [{query: gqlDashboard.Dashboards}],
@@ -156,137 +161,187 @@ export const DashboardPage: React.FC<RouterProps> = ({match, history}) => {
         }).then(console.log);
     };
 
-    return (
-        <>
-            <div style={{display: 'flex'}}>
-                <div style={{flex: 1}}>
-                    <DateRanges setRanges={setRanges} ranges={ranges} changeMode={changeMode} dashboard={dashboard} />
-                </div>
-                <div>
-                    {changeMode ? (
-                        <Button
-                            onClick={() => setViewType(viewType === ViewType.Desktop ? ViewType.Mobile : ViewType.Desktop)}
-                            variant={'outlined'}
-                            style={{marginRight: 10}}>
-                            {viewType === ViewType.Mobile ? 'Desktop View' : 'Mobile View'}
-                        </Button>
-                    ) : null}
-                    {changeMode ? (
-                        <Button
-                            onClick={() => {
-                                setAddEntry(newEntry());
-                                endRef.current!.scrollIntoView({behavior: 'smooth'});
-                            }}
-                            variant={'outlined'}
-                            style={{marginRight: 10}}>
-                            Add Entry
-                        </Button>
-                    ) : null}
+    let content: React.ReactNode;
+    if (externalUrl) {
+        content = (
+            <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
+                <div style={{display: 'flex', alignItems: 'center', marginBottom: 10}}>
+                    <div style={{flex: 1}}>
+                        <Typography variant={'h5'}>Dashboard: {dashboard.name}</Typography>
+                    </div>
                     <Button
-                        onClick={() => {
-                            setViewType(ViewType.Desktop);
-                            setChangeMode(!changeMode);
-                        }}
+                        href={externalUrl}
+                        target={'_blank'}
+                        rel={'noopener noreferrer'}
                         variant={'outlined'}
                         color={'primary'}
                         style={{marginRight: 10}}>
-                        {changeMode ? 'Exit Editing' : 'Edit Dashboard'}
+                        Open externally
+                    </Button>
+                    <Button variant={'outlined'} onClick={() => setExternalDialogOpen(true)}>
+                        Configure
                     </Button>
                 </div>
+                <iframe
+                    src={kioskUrl(externalUrl)}
+                    title={dashboard.name}
+                    style={{width: '100%', flex: 1, border: 0, minHeight: 0}}
+                />
             </div>
-            <div
-                style={
-                    viewType === ViewType.Desktop
-                        ? {}
-                        : {borderRight: '5px dotted grey', borderLeft: '5px dotted grey', maxWidth: 700, margin: '0 auto'}
-                }>
-                <WidthAwareReactGrid
-                    key={viewType}
-                    cols={cols[viewType]}
-                    className="layout"
-                    rowHeight={50}
-                    preventCollision={true}
-                    useCSSTransforms={false}
-                    autoSize={true}
-                    layout={l}
-                    onDragStop={updatePosHandler}
-                    onResizeStop={updatePosHandler}
-                    compactType={null}
-                    isResizable={changeMode}
-                    isDraggable={changeMode}>
-                    {dashboardEntries.map((entry) => {
-                        const currentEditedAndPreviewed = preview && editEntry && editEntry.id === entry.id;
-                        return (
-                            <div key={'' + entry.id}>
-                                <DashboardEntry ranges={indexedRanges} entry={currentEditedAndPreviewed ? editEntry! : entry} />
-                                {changeMode ? (
-                                    <Fade fullyVisible={!currentEditedAndPreviewed} opacity={0}>
-                                        <EditGlass
-                                            doEdit={(elm) => setEdit([elm, clone(entry)])}
-                                            doDelete={() => removeDashboardEntry({variables: {id: entry.id}})}
-                                        />
-                                    </Fade>
+        );
+    } else {
+        content = (
+            <>
+                <div style={{display: 'flex'}}>
+                    <div style={{flex: 1}}>
+                        <DateRanges setRanges={setRanges} ranges={ranges} changeMode={changeMode} dashboard={dashboard} />
+                    </div>
+                    <div>
+                        {changeMode ? (
+                            <Button
+                                onClick={() => setViewType(viewType === ViewType.Desktop ? ViewType.Mobile : ViewType.Desktop)}
+                                variant={'outlined'}
+                                style={{marginRight: 10}}>
+                                {viewType === ViewType.Mobile ? 'Desktop View' : 'Mobile View'}
+                            </Button>
+                        ) : null}
+                        {changeMode ? (
+                            <Button
+                                onClick={() => {
+                                    setAddEntry(newEntry());
+                                    endRef.current!.scrollIntoView({behavior: 'smooth'});
+                                }}
+                                variant={'outlined'}
+                                style={{marginRight: 10}}>
+                                Add Entry
+                            </Button>
+                        ) : null}
+                        <Button onClick={() => setExternalDialogOpen(true)} variant={'outlined'} style={{marginRight: 10}}>
+                            External View
+                        </Button>
+                        <Button
+                            onClick={() => {
+                                setViewType(ViewType.Desktop);
+                                setChangeMode(!changeMode);
+                            }}
+                            variant={'outlined'}
+                            color={'primary'}
+                            style={{marginRight: 10}}>
+                            {changeMode ? 'Exit Editing' : 'Edit Dashboard'}
+                        </Button>
+                    </div>
+                </div>
+                <div
+                    style={
+                        viewType === ViewType.Desktop
+                            ? {}
+                            : {borderRight: '5px dotted grey', borderLeft: '5px dotted grey', maxWidth: 700, margin: '0 auto'}
+                    }>
+                    <WidthAwareReactGrid
+                        key={viewType}
+                        cols={cols[viewType]}
+                        className="layout"
+                        rowHeight={50}
+                        preventCollision={true}
+                        useCSSTransforms={false}
+                        autoSize={true}
+                        layout={l}
+                        onDragStop={updatePosHandler}
+                        onResizeStop={updatePosHandler}
+                        compactType={null}
+                        isResizable={changeMode}
+                        isDraggable={changeMode}>
+                        {dashboardEntries.map((entry) => {
+                            const currentEditedAndPreviewed = preview && editEntry && editEntry.id === entry.id;
+                            return (
+                                <div key={'' + entry.id}>
+                                    <DashboardEntry
+                                        ranges={indexedRanges}
+                                        entry={currentEditedAndPreviewed ? editEntry! : entry}
+                                    />
+                                    {changeMode ? (
+                                        <Fade fullyVisible={!currentEditedAndPreviewed} opacity={0}>
+                                            <EditGlass
+                                                doEdit={(elm) => setEdit([elm, clone(entry)])}
+                                                doDelete={() => removeDashboardEntry({variables: {id: entry.id}})}
+                                            />
+                                        </Fade>
+                                    ) : null}
+                                </div>
+                            );
+                        })}
+                        {addEntry ? (
+                            <div
+                                key={'' + EditId}
+                                ref={(ref: HTMLDivElement) => {
+                                    setAddRef(ref);
+                                    if (ref) {
+                                        ref.scrollIntoView({behavior: 'smooth'});
+                                    }
+                                }}>
+                                {preview ? (
+                                    <DashboardEntry ranges={indexedRanges} key="uff" entry={addEntry} />
+                                ) : (
+                                    <Paper style={{width: '100%', height: '100%'}}>
+                                        <Center>New Entry</Center>
+                                    </Paper>
+                                )}
+
+                                {addRef ? (
+                                    <AddPopup
+                                        maxY={maxY}
+                                        dashboardId={dashboard.id}
+                                        preview={preview}
+                                        ranges={rangeToName()}
+                                        doPreview={setPreview}
+                                        entry={addEntry}
+                                        anchorEl={addRef}
+                                        onChange={(e) => {
+                                            return setAddEntry(clone(e));
+                                        }}
+                                        finish={() => {
+                                            setAddEntry(null);
+                                            setAddRef(null);
+                                        }}
+                                    />
                                 ) : null}
                             </div>
-                        );
-                    })}
-                    {addEntry ? (
-                        <div
-                            key={'' + EditId}
-                            ref={(ref: HTMLDivElement) => {
-                                setAddRef(ref);
-                                if (ref) {
-                                    ref.scrollIntoView({behavior: 'smooth'});
-                                }
-                            }}>
-                            {preview ? (
-                                <DashboardEntry ranges={indexedRanges} key="uff" entry={addEntry} />
-                            ) : (
-                                <Paper style={{width: '100%', height: '100%'}}>
-                                    <Center>New Entry</Center>
-                                </Paper>
-                            )}
-
-                            {addRef ? (
-                                <AddPopup
-                                    maxY={maxY}
-                                    dashboardId={dashboard.id}
-                                    preview={preview}
-                                    ranges={rangeToName()}
-                                    doPreview={setPreview}
-                                    entry={addEntry}
-                                    anchorEl={addRef}
-                                    onChange={(e) => {
-                                        return setAddEntry(clone(e));
-                                    }}
-                                    finish={() => {
-                                        setAddEntry(null);
-                                        setAddRef(null);
-                                    }}
-                                />
-                            ) : null}
-                        </div>
-                    ) : (
-                        []
-                    )}
-                </WidthAwareReactGrid>
-            </div>
-            {editElement !== null && editEntry !== null ? (
-                <EditPopup
-                    preview={preview}
-                    ranges={rangeToName()}
-                    doPreview={setPreview}
-                    entry={editEntry!}
-                    anchorEl={editElement}
-                    onChange={(entry) => {
-                        if (entry === null) {
-                            setEdit([null]);
-                        } else {
-                            setEdit([editElement, entry]);
-                        }
-                    }}
-                />
-            ) : null}
+                        ) : (
+                            []
+                        )}
+                    </WidthAwareReactGrid>
+                </div>
+                {editElement !== null && editEntry !== null ? (
+                    <EditPopup
+                        preview={preview}
+                        ranges={rangeToName()}
+                        doPreview={setPreview}
+                        entry={editEntry!}
+                        anchorEl={editElement}
+                        onChange={(entry) => {
+                            if (entry === null) {
+                                setEdit([null]);
+                            } else {
+                                setEdit([editElement, entry]);
+                            }
+                        }}
+                    />
+                ) : null}
+            </>
+        );
+    }
+    return (
+        <>
+            {content}
+            <ExternalUrlDialog
+                open={externalDialogOpen}
+                url={externalUrl}
+                onSave={(url) => {
+                    setExternalUrl(dashboard.id, url);
+                    setExternalUrlState(url);
+                }}
+                onClose={() => setExternalDialogOpen(false)}
+            />
             <div ref={endRef} />
         </>
     );

--- a/ui/src/dashboard/ExternalView.test.tsx
+++ b/ui/src/dashboard/ExternalView.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {act} from 'react-dom/test-utils';
+import {ExternalUrlDialog, getExternalUrl, kioskUrl, setExternalUrl} from './ExternalView';
+
+describe('external url storage', () => {
+    beforeEach(() => localStorage.clear());
+
+    it('stores and reads the url per dashboard, trimmed', () => {
+        setExternalUrl(1, '  http://example.com/dash  ');
+        expect(getExternalUrl(1)).toBe('http://example.com/dash');
+        expect(getExternalUrl(2)).toBe('');
+    });
+
+    it('clears the stored url when input is empty', () => {
+        setExternalUrl(1, 'http://example.com');
+        setExternalUrl(1, '   ');
+        expect(getExternalUrl(1)).toBe('');
+    });
+
+    it('kioskUrl is the identity', () => {
+        expect(kioskUrl('http://example.com')).toBe('http://example.com');
+    });
+});
+
+describe('ExternalUrlDialog', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('renders title, helper text and buttons', () => {
+        act(() => {
+            ReactDOM.render(
+                <ExternalUrlDialog open={true} url={''} onSave={jest.fn()} onClose={jest.fn()} />,
+                document.createElement('div')
+            );
+        });
+        expect(document.body.textContent).toContain('External dashboard URL');
+        expect(document.body.textContent).toContain('Leave empty to use the built-in Traggo dashboard');
+        expect(document.body.textContent).toContain('Save');
+    });
+
+    it('calls onSave with the empty string on Clear', () => {
+        const onSave = jest.fn();
+        act(() => {
+            ReactDOM.render(
+                <ExternalUrlDialog open={true} url={'http://example.com'} onSave={onSave} onClose={jest.fn()} />,
+                document.createElement('div')
+            );
+        });
+        const buttons = Array.from(document.querySelectorAll('button'));
+        const clear = buttons.find((b) => b.textContent === 'Clear');
+        expect(clear).toBeDefined();
+        act(() => {
+            clear!.click();
+        });
+        expect(onSave).toHaveBeenCalledWith('');
+    });
+});

--- a/ui/src/dashboard/ExternalView.tsx
+++ b/ui/src/dashboard/ExternalView.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import TextField from '@material-ui/core/TextField';
+
+const storageKey = (dashboardId: number) => `traggo-external-url-${dashboardId}`;
+
+// The external URL is stored per-browser in localStorage (frontend-only feature);
+// it does not sync across devices for the same Traggo user. Accepted limitation.
+export const getExternalUrl = (dashboardId: number): string => {
+    try {
+        return localStorage.getItem(storageKey(dashboardId)) || '';
+    } catch {
+        return '';
+    }
+};
+
+export const setExternalUrl = (dashboardId: number, url: string): void => {
+    const trimmed = url.trim();
+    try {
+        if (trimmed) {
+            localStorage.setItem(storageKey(dashboardId), trimmed);
+        } else {
+            localStorage.removeItem(storageKey(dashboardId));
+        }
+    } catch {
+        // storage unavailable; the dashboard falls back to the built-in view
+    }
+};
+
+export const kioskUrl = (url: string): string => url;
+
+export const ExternalUrlDialog: React.FC<{
+    open: boolean;
+    url: string;
+    onSave: (url: string) => void;
+    onClose: () => void;
+}> = ({open, url, onSave, onClose}) => {
+    const [value, setValue] = React.useState(url);
+    React.useEffect(() => setValue(url), [open, url]);
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+            <DialogTitle>External dashboard URL</DialogTitle>
+            <DialogContent>
+                <TextField
+                    autoFocus
+                    fullWidth
+                    label="Dashboard URL"
+                    placeholder="http://localhost:3000/d/traggo-study-overview/traggo-overview"
+                    value={value}
+                    onChange={(event) => setValue(event.target.value)}
+                    helperText="Leave empty to use the built-in Traggo dashboard"
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    onClick={() => {
+                        onSave('');
+                        onClose();
+                    }}>
+                    Clear
+                </Button>
+                <Button
+                    color={'primary'}
+                    onClick={() => {
+                        onSave(value);
+                        onClose();
+                    }}>
+                    Save
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};


### PR DESCRIPTION
## Summary

Adds an opt-in external view to every dashboard. When a URL is configured for
a dashboard, it renders inside a full-size iframe instead of the widget grid.
The default Traggo behaviour, data model and API are unchanged — the feature
is fully client-side and opt-in per dashboard.

## What changed

- **`ui/src/dashboard/ExternalView.tsx`** (new)
  - `getExternalUrl(id)` / `setExternalUrl(id, url)` — persist the external URL
    per dashboard in `localStorage` (trimmed; empty value clears the entry)
  - `ExternalUrlDialog` — dialog to set/clear the URL
  - `kioskUrl(url)` — identity function; URLs are embedded as-is
- **`ui/src/dashboard/ExternalView.test.tsx`** (new) — unit tests for the
  storage helpers and the dialog
- **`ui/src/dashboard/DashboardPage.tsx`** — "External View" configuration button,
  embedded iframe view (flexbox layout) and "Open externally" action; both
  views share a single dialog instance
- **`grafana/README.md`** (new) — deployment guide for running Traggo together
  with Grafana (or any other tool): building the image, Podman pod setup,
  SELinux, file permissions for the non-root Grafana user, datasource and
  dashboard provisioning, Docker Compose alternative, troubleshooting

## How it works

1. Open a dashboard → "External View" → paste the dashboard URL
   (e.g. `http://localhost:3000/d/traggo-study-overview/traggo-overview?orgId=1&from=now-30d&to=now&timezone=browser&var-tag=$__all&refresh=1m` or 
`http://localhost:3000/d/traggo-study-overview/traggo-overview?orgId=1&from=now-30d&to=now&timezone=browser&var-tag=$__all&refresh=1m&kiosk`) → Save
2. The dashboard now renders the URL in an iframe; "Open externally" opens it
   in a new tab, "Configure" changes the URL, "Clear" restores the widget grid
3. The URL is used exactly as stored — no transformation. Adding a kiosk
   parameter (e.g. Grafana `?kiosk`) is optional and only hides the tool's chrome
4. The URL is stored per dashboard in `localStorage` (per browser, not synced)

## Verification

- `tsc --noEmit` clean
- New tests pass (5/5)
- `make lint` green (go vet, goimports, prettier, tslint)
- Production build and end-to-end deployment tested (Podman pod, Grafana 11.5.2
  + frser-sqlite-datasource)
  
Tested on Fedora Linux 43 (Workstation Edition), kernel 7.1.4-104.fc43.x86_64, browser: Helium 0.14.9.1 (Official Build, 64-bit) on Chromium 150.0.7871.186 (rpm), V8 15.0.245.21, Wayland

<img width="1901" height="988" alt="Screenshot From 2026-08-01 19-46-57" src="https://github.com/user-attachments/assets/a070f727-6128-4c3c-bc9c-9eafb29c4c4e" />
<img width="1901" height="988" alt="Screenshot From 2026-08-01 19-47-06" src="https://github.com/user-attachments/assets/9e94758e-660a-4bab-bd19-9b13a2140011" />
<img width="1901" height="988" alt="Screenshot From 2026-08-01 19-47-31" src="https://github.com/user-attachments/assets/31ee90b1-174c-4538-b4ea-9b9dbbd79d0f" />
<img width="1901" height="988" alt="Screenshot From 2026-08-01 19-47-44" src="https://github.com/user-attachments/assets/54b4ec5f-832b-4187-837d-f0de2dc04dce" />
